### PR TITLE
CoreDataPersistable 프로토콜을 채택한 구현체를 테스트하기 위한 테스트 코드 작성

### DIFF
--- a/RetsTalk/RetsTalk.xcodeproj/project.pbxproj
+++ b/RetsTalk/RetsTalk.xcodeproj/project.pbxproj
@@ -42,6 +42,27 @@
 			);
 			target = 21759C3A2CD8AE0D0033EA52 /* RetsTalk */;
 		};
+		BA99E4FE2CE58E7A001CBB80 /* Exceptions for "RetsTalk" folder in "RetsTalkTests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Data/Persistent/CoreDataPersistable.swift,
+				Data/Persistent/CoreDataStorage.swift,
+				"Data/Persistent/MessageEntity+CoreDataClass.swift",
+				"Data/Persistent/RetrospectEntity+CoreDataClass.swift",
+				Domain/Message.swift,
+				Domain/Retrospect.swift,
+				RetsTalk.xcdatamodeld,
+			);
+			target = 21759C532CD8AE0F0033EA52 /* RetsTalkTests */;
+		};
+		BA99E50B2CE5B97A001CBB80 /* Exceptions for "RetsTalkTests" folder in "RetsTalkTests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				CoreDataTests/MessageTest.swift,
+				CoreDataTests/RetrospectTest.swift,
+			);
+			target = 21759C532CD8AE0F0033EA52 /* RetsTalkTests */;
+		};
 		D59E35E42CD9F389001B6D5A /* Exceptions for "RetsTalk" folder in "NetworkTests" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -62,6 +83,7 @@
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				21759C662CD8AE0F0033EA52 /* Exceptions for "RetsTalk" folder in "RetsTalk" target */,
+				BA99E4FE2CE58E7A001CBB80 /* Exceptions for "RetsTalk" folder in "RetsTalkTests" target */,
 				D59E35E42CD9F389001B6D5A /* Exceptions for "RetsTalk" folder in "NetworkTests" target */,
 			);
 			path = RetsTalk;
@@ -69,6 +91,9 @@
 		};
 		21759C572CD8AE0F0033EA52 /* RetsTalkTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				BA99E50B2CE5B97A001CBB80 /* Exceptions for "RetsTalkTests" folder in "RetsTalkTests" target */,
+			);
 			path = RetsTalkTests;
 			sourceTree = "<group>";
 		};

--- a/RetsTalk/RetsTalk/RetsTalk.xcdatamodeld/RetsTalk.xcdatamodel/contents
+++ b/RetsTalk/RetsTalk/RetsTalk.xcdatamodeld/RetsTalk.xcdatamodel/contents
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="24A348" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="24B83" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="MessageEntity" representedClassName=".MessageEntity" syncable="YES" codeGenerationType="category">
         <attribute name="content" attributeType="String"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="isUser" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <relationship name="retrospect" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RetrospectEntity" inverseName="chat" inverseEntity="RetrospectEntity"/>
+    </entity>
+    <entity name="MessageTestEntity" representedClassName="MessageTestEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="content" attributeType="String"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="isUser" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="retrospect" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RetrospectTestEntity" inverseName="chat" inverseEntity="RetrospectTestEntity"/>
     </entity>
     <entity name="RetrospectEntity" representedClassName=".RetrospectEntity" syncable="YES" codeGenerationType="category">
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
@@ -12,5 +18,12 @@
         <attribute name="isFinished" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="summary" optional="YES" attributeType="String"/>
         <relationship name="chat" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageEntity" inverseName="retrospect" inverseEntity="MessageEntity"/>
+    </entity>
+    <entity name="RetrospectTestEntity" representedClassName="RetrospectTestEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="isBookmarked" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isFinished" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="summary" optional="YES" attributeType="String"/>
+        <relationship name="chat" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageTestEntity" inverseName="retrospect" inverseEntity="MessageTestEntity"/>
     </entity>
 </model>

--- a/RetsTalk/RetsTalkTests/CoreDataTests/CoreDataPersistableTests.swift
+++ b/RetsTalk/RetsTalkTests/CoreDataTests/CoreDataPersistableTests.swift
@@ -82,7 +82,7 @@ final class CoreDataPersistableTests: XCTestCase {
         // given
         let repeatingNumber = 5
         let fetchLimit = 2
-        try addDummyEntities(repeating: 5)
+        try addDummyEntities(repeating: repeatingNumber)
 
         // when
         let fetchRequest = MessageTestEntity.fetchRequest()

--- a/RetsTalk/RetsTalkTests/CoreDataTests/CoreDataPersistableTests.swift
+++ b/RetsTalk/RetsTalkTests/CoreDataTests/CoreDataPersistableTests.swift
@@ -17,12 +17,11 @@ final class CoreDataPersistableTests: XCTestCase {
 
     func test_add결과_예상과_동일() throws {
         // given
-        let content: String = "Hello"
+        let content = "Hello"
 
         // when
-        let message = try addDummyEntity(content: content)
-        guard let message = message as? MessageTestEntity else {
-            XCTFail("add 결과가 MessageTestEntity 타입이 아님")
+        guard let message = try addDummyEntity(content: content) else {
+            XCTFail("add 결과가 올바르지 않아서 nil 반환")
             return
         }
 
@@ -32,7 +31,7 @@ final class CoreDataPersistableTests: XCTestCase {
 
     func test_fetch가_엔티티_수만큼_반환() async throws {
         // given
-        let repeatingNumber: Int = 5
+        let repeatingNumber = 5
         try addDummyEntities(repeating: repeatingNumber)
 
         // when
@@ -45,31 +44,27 @@ final class CoreDataPersistableTests: XCTestCase {
 
     func test_update를_통해_엔티티_수정() throws {
         // given
-        let entity = try addDummyEntity(content: "Hello")
-        guard let entity else {
-            XCTFail("add 결과가 MessageTestEntity 타입이 아님")
+        guard let entity = try addDummyEntity(content: "Hello") else {
+            XCTFail("add 결과가 올바르지 않아서 nil 반환")
             return
         }
 
         // when
         let updatedEntity = try coreDataManager?.update(entity: entity) { entity in
-            guard let entity = entity as? MessageTestEntity else { return }
-
             entity.content = "World"
         }
 
         // then
-        guard let updatedEntity = updatedEntity as? MessageTestEntity else { return }
+        guard let updatedEntity else { return }
 
         XCTAssertEqual(updatedEntity.content, "World")
     }
 
     func test_delete_단일_객체() async throws {
         // given
-        let content: String = "Hello"
-        let entity = try addDummyEntity(content: content)
-        guard let entity else {
-            XCTFail("add 결과가 MessageTestEntity 타입이 아님")
+        let content = "Hello"
+        guard let entity = try addDummyEntity(content: content) else {
+            XCTFail("add 결과가 올바르지 않아서 nil 반환")
             return
         }
 
@@ -80,13 +75,13 @@ final class CoreDataPersistableTests: XCTestCase {
         let fetchRequest = MessageTestEntity.fetchRequest()
         guard let fetchedMessages = try await coreDataManager?.fetch(by: fetchRequest) else { return }
 
-        XCTAssertEqual(fetchedMessages.count, 0)
+        XCTAssertTrue(fetchedMessages.isEmpty)
     }
 
     func test_delete_복수_객체() async throws {
         // given
-        let repeatingNumber: Int = 5
-        let fetchLimit: Int = 2
+        let repeatingNumber = 5
+        let fetchLimit = 2
         try addDummyEntities(repeating: 5)
 
         // when
@@ -102,7 +97,7 @@ final class CoreDataPersistableTests: XCTestCase {
 
     // MARK: Helper
 
-    private func addDummyEntity(content: String) throws -> NSManagedObject? {
+    private func addDummyEntity(content: String) throws -> MessageEntity? {
         let message = try coreDataManager?.add(entityProvider: { context in
             let message = MessageTestEntity(context: context)
             message.content = content
@@ -110,7 +105,7 @@ final class CoreDataPersistableTests: XCTestCase {
             message.isUser = true
             return message
         })
-        return message
+        return message as? MessageEntity
     }
 
     private func addDummyEntities(repeating: Int) throws {

--- a/RetsTalk/RetsTalkTests/CoreDataTests/CoreDataPersistableTests.swift
+++ b/RetsTalk/RetsTalkTests/CoreDataTests/CoreDataPersistableTests.swift
@@ -1,0 +1,127 @@
+//
+//  CoreDataPersistableTests.swift
+//  RetsTalkTests
+//
+//  Created by MoonGoon on 11/14/24.
+//
+
+import XCTest
+import CoreData
+
+final class CoreDataPersistableTests: XCTestCase {
+    private var coreDataManager: CoreDataPersistable?
+
+    // MARK: Set up and tear down
+
+    // MARK: Test
+
+    func test_add결과_예상과_동일() async throws {
+        // given
+        let content: String = "Hello"
+
+        // when
+        let message = try addDummyEntity(content: content)
+        guard let message = message as? MessageTestEntity else {
+            XCTFail("add 결과가 MessageTestEntity 타입이 아님")
+            return
+        }
+
+        // then
+        XCTAssertEqual(message.content, content)
+    }
+
+    func test_fetch가_엔티티_수만큼_반환() async throws {
+        // given
+        let repeatingNumber: Int = 5
+        try addDummyEntities(repeating: repeatingNumber)
+
+        // when
+        let fetchRequest = MessageTestEntity.fetchRequest()
+        guard let fetchedMessages = try await coreDataManager?.fetch(by: fetchRequest) else { return }
+
+        // then
+        XCTAssertEqual(fetchedMessages.count, repeatingNumber)
+    }
+
+    func test_update를_통해_엔티티_수정() async throws {
+        // given
+        let entity = try addDummyEntity(content: "Hello")
+        guard let entity else {
+            XCTFail("add 결과가 MessageTestEntity 타입이 아님")
+            return
+        }
+
+        // when
+        let updatedEntity = try coreDataManager?.update(entity: entity) { entity in
+            guard let entity = entity as? MessageTestEntity else { return }
+
+            entity.content = "World"
+        }
+
+        // then
+        guard let updatedEntity = updatedEntity as? MessageTestEntity else { return }
+
+        XCTAssertEqual(updatedEntity.content, "World")
+    }
+
+    func test_delete_단일_객체() async throws {
+        // given
+        let content: String = "Hello"
+        let entity = try addDummyEntity(content: content)
+        guard let entity else {
+            XCTFail("add 결과가 MessageTestEntity 타입이 아님")
+            return
+        }
+
+        // when
+        try coreDataManager?.delete(entity: entity)
+
+        // then
+        let fetchRequest = MessageTestEntity.fetchRequest()
+        guard let fetchedMessages = try await coreDataManager?.fetch(by: fetchRequest) else { return }
+
+        XCTAssertEqual(fetchedMessages.count, 0)
+    }
+
+    func test_delete_복수_객체() async throws {
+        // given
+        let repeatingNumber: Int = 5
+        let fetchLimit: Int = 2
+        try addDummyEntities(repeating: 5)
+
+        // when
+        let fetchRequest = MessageTestEntity.fetchRequest()
+        fetchRequest.fetchLimit = fetchLimit
+        try await coreDataManager?.delete(by: fetchRequest)
+
+        // then
+        guard let fetchedMessages = try await coreDataManager?.fetch(by: fetchRequest) else { return }
+
+        XCTAssertEqual(fetchedMessages.count, repeatingNumber - fetchLimit)
+    }
+
+    // MARK: Helper
+
+    private func addDummyEntity(content: String) throws -> NSManagedObject? {
+        let message = try coreDataManager?.add(entityProvider: { context in
+            let message = MessageTestEntity(context: context)
+            message.content = content
+            message.createdAt = Date()
+            message.isUser = true
+            return message
+        })
+        return message
+    }
+
+    private func addDummyEntities(repeating: Int) throws {
+        for _ in 0..<repeating {
+            _ = try coreDataManager?.add(entityProvider: { context in
+                let message = MessageTestEntity(context: context)
+                message.content = "Hello"
+                message.createdAt = Date()
+                message.isUser = true
+                return message
+            })
+        }
+    }
+}

--- a/RetsTalk/RetsTalkTests/CoreDataTests/CoreDataPersistableTests.swift
+++ b/RetsTalk/RetsTalkTests/CoreDataTests/CoreDataPersistableTests.swift
@@ -15,7 +15,7 @@ final class CoreDataPersistableTests: XCTestCase {
 
     // MARK: Test
 
-    func test_add결과_예상과_동일() async throws {
+    func test_add결과_예상과_동일() throws {
         // given
         let content: String = "Hello"
 
@@ -43,7 +43,7 @@ final class CoreDataPersistableTests: XCTestCase {
         XCTAssertEqual(fetchedMessages.count, repeatingNumber)
     }
 
-    func test_update를_통해_엔티티_수정() async throws {
+    func test_update를_통해_엔티티_수정() throws {
         // given
         let entity = try addDummyEntity(content: "Hello")
         guard let entity else {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

Closes #39 

## ✨ 세부 내용

CoreDataPersistable 인터페이스를 채택한 구현체의 동작을 테스트하기 위한 테스트 코드를 작성하였습니다.

## ✍️ 고민한 내용

fetch와 delete를 제외한 add와 update 로직은 올바르게 동작했을 경우 entity를 반환하기 때문에 fetch를 진행하지 않았습니다.

dummyData를 add 하는 함수를 따로 빼서 가독성을 높혔습니다.
## ⌛ 소요 시간

5h..