### PR TITLE
Assets에 Color asset 추가

### DIFF
--- a/RetsTalk/RetsTalk/App/AppDelegate.swift
+++ b/RetsTalk/RetsTalk/App/AppDelegate.swift
@@ -16,5 +16,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
         return true
     }
-
 }

--- a/RetsTalk/RetsTalk/Assets.xcassets/BackgroundMain.colorset/Contents.json
+++ b/RetsTalk/RetsTalk/Assets.xcassets/BackgroundMain.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFA",
+          "green" : "0xFA",
+          "red" : "0xFA"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RetsTalk/RetsTalk/Assets.xcassets/BackgroundRetrospect.colorset/Contents.json
+++ b/RetsTalk/RetsTalk/Assets.xcassets/BackgroundRetrospect.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RetsTalk/RetsTalk/Assets.xcassets/BlazingOrange.colorset/Contents.json
+++ b/RetsTalk/RetsTalk/Assets.xcassets/BlazingOrange.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4A",
+          "green" : "0xA4",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RetsTalk/RetsTalk/Assets.xcassets/BlueBerry.colorset/Contents.json
+++ b/RetsTalk/RetsTalk/Assets.xcassets/BlueBerry.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x50",
+          "green" : "0x3E",
+          "red" : "0x2C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RetsTalk/RetsTalk/Assets.xcassets/StrokeRetrospect.colorset/Contents.json
+++ b/RetsTalk/RetsTalk/Assets.xcassets/StrokeRetrospect.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF1",
+          "green" : "0xF1",
+          "red" : "0xF1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RetsTalk/RetsTalk/Info.plist
+++ b/RetsTalk/RetsTalk/Info.plist
@@ -19,5 +19,7 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

Closes #41 

## ✨ 세부 내용

Hex 값을 직접 사용하던 기존 코드 대신 사용하기 위한 color asset들을 추가함

<!-- 수정/추가한 내용을 적어주세요. -->

## ✍️ 고민한 내용

<!-- 해당 PR중 고민한 내용이 있으면 적어주세요. -->

## ⌛ 소요 시간
10m