### PR TITLE
회고와,메시지 관리자 구현체 기본 구성하고 Delegate로 이어주기

### DIFF
--- a/RetsTalk/RetsTalk/Chat/Model/MessageManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/MessageManager.swift
@@ -1,0 +1,31 @@
+//
+//  MessageManager.swift
+//  RetsTalk
+//
+//  Created by KimMinSeok on 11/19/24.
+//
+
+import Foundation
+
+final class MessageManager: MessageManageable {
+    let retrospectID: UUID
+    private(set) var messages: [Message] = []
+    private(set) var messageManagerListener: MessageManagerListener
+    
+    init(retrospectID: UUID, messageManagerListener: MessageManagerListener) {
+        self.retrospectID = retrospectID
+        self.messageManagerListener = messageManagerListener
+    }
+    
+    func fetchMessages(offset: Int, amount: Int) {
+        
+    }
+    
+    func send(_ message: Message) {
+        
+    }
+    
+    func endRetrospect() {
+        
+    }
+}

--- a/RetsTalk/RetsTalk/Chat/Model/MessageManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/MessageManager.swift
@@ -26,6 +26,6 @@ final class MessageManager: MessageManageable {
     }
     
     func endRetrospect() {
-        
+        messageManagerListener.didFinishRetrospect(self)
     }
 }

--- a/RetsTalk/RetsTalk/Chat/Model/MessageManagerListener.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/MessageManagerListener.swift
@@ -6,5 +6,6 @@
 //
 
 protocol MessageManagerListener {
-    
+    func didFinishRetrospect(_ messageManager: MessageManager)
+    func didChangStatus(_ messageManager: MessageManager, to status: Retrospect.Status)
 }

--- a/RetsTalk/RetsTalk/Chat/Model/MessageManagerListener.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/MessageManagerListener.swift
@@ -7,5 +7,5 @@
 
 protocol MessageManagerListener {
     func didFinishRetrospect(_ messageManager: MessageManager)
-    func didChangStatus(_ messageManager: MessageManager, to status: Retrospect.Status)
+    func didChangeStatus(_ messageManager: MessageManager, to status: Retrospect.Status)
 }

--- a/RetsTalk/RetsTalk/Chat/Model/MessageManagerListener.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/MessageManagerListener.swift
@@ -6,6 +6,6 @@
 //
 
 protocol MessageManagerListener {
-    func didFinishRetrospect(_ messageManager: MessageManager)
-    func didChangeStatus(_ messageManager: MessageManager, to status: Retrospect.Status)
+    func didFinishRetrospect(_ messageManager: MessageManageable)
+    func didChangeStatus(_ messageManager: MessageManageable, to status: Retrospect.Status)
 }

--- a/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
@@ -8,21 +8,29 @@
 import Foundation
 
 struct Retrospect {
-    let id: UUID = UUID()
-    let author: User
-    let summary: String? = nil
-    var status: Status = .progress(.inputWaiting)
-    let isPinned: Bool = false
-    let createdAt: Date = Date()
+    let id: UUID
+    let user: User
+    var summary: String?
+    var status: Status
+    var isPinned: Bool
+    let createdAt: Date
     
-    enum Status {
-        case finish
-        case progress(LastStatus)
+    init(user: User) {
+        self.id = UUID()
+        self.user = user
+        self.status = .inProgress(.waitingForUserInput)
+        self.isPinned = false
+        self.createdAt = Date()
     }
     
-    enum LastStatus {
-        case responseError
-        case inputWaiting
-        case responseWaiting
+    enum Status {
+        case finished
+        case inProgress(ProgressStatus)
+    }
+    
+    enum ProgressStatus {
+        case responseErrorOccurred
+        case waitingForUserInput
+        case waitingForResponse
     }
 }

--- a/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
@@ -8,9 +8,21 @@
 import Foundation
 
 struct Retrospect {
-    let summary: String?
-    let isFinished: Bool
-    let isBookmarked: Bool
-    let createdAt: Date
-    let chat: [Message]
+    let id: UUID = UUID()
+    let author: User
+    let summary: String? = nil
+    var status: Status = .progress(.inputWaiting)
+    let isPinned: Bool = false
+    let createdAt: Date = Date()
+    
+    enum Status {
+        case finish
+        case progress(LastStatus)
+    }
+    
+    enum LastStatus {
+        case responseError
+        case inputWaiting
+        case responseWaiting
+    }
 }

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManageable.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManageable.swift
@@ -8,7 +8,8 @@
 protocol RetrospectManageable {
     var retrospects: [Retrospect] { get }
     
-    func fetchRetrospects(offset: Int, mount: Int)
+    func fetchRetrospects(offset: Int, amount: Int)
     func create()
+    func update(_ retrospect: Retrospect)
     func delete(_ retrospect: Retrospect)
 }

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -17,7 +17,15 @@ final class RetrospectManager: RetrospectManageable {
     }
     
     func create() {
-    
+        let retropsect = Retrospect(author: User(nickname: "alstjr"))
+        
+        let messageManager = MessageManager(
+            retrospectID: retropsect.id,
+            messageManagerListener: self
+        )
+        
+        retrospects.append(retropsect)
+        messageMap[retropsect.id] = messageManager
     }
     
     func delete(_ retrospect: Retrospect) {

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -1,0 +1,26 @@
+//
+//  RetrospectManager.swift
+//  RetsTalk
+//
+//  Created by KimMinSeok on 11/19/24.
+//
+
+import Foundation
+
+final class RetrospectManager: RetrospectManageable {
+    private(set) var retrospects: [Retrospect] = []
+    
+    fileprivate var messageMap: [UUID: MessageManageable] = [:]
+    
+    func fetchRetrospects(offset: Int, mount: Int) {
+        
+    }
+    
+    func create() {
+    
+    }
+    
+    func delete(_ retrospect: Retrospect) {
+        
+    }
+}

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -9,22 +9,25 @@ import Foundation
 
 final class RetrospectManager: RetrospectManageable {
     private(set) var retrospects: [Retrospect] = []
-    fileprivate var messageMap: [UUID: MessageManageable] = [:]
+    fileprivate var messageManagerMapping: [UUID: MessageManageable] = [:]
     
-    func fetchRetrospects(offset: Int, mount: Int) {
+    func fetchRetrospects(offset: Int, amount: Int) {
         
     }
     
     func create() {
-        let retropsect = Retrospect(author: User(nickname: "alstjr"))
-        
+        let retropsect = Retrospect(user: User(nickname: "alstjr"))
         let messageManager = MessageManager(
             retrospectID: retropsect.id,
             messageManagerListener: self
         )
         
         retrospects.append(retropsect)
-        messageMap[retropsect.id] = messageManager
+        messageManagerMapping[retropsect.id] = messageManager
+    }
+    
+    func update(_ retrospect: Retrospect) {
+        
     }
     
     func delete(_ retrospect: Retrospect) {
@@ -32,18 +35,20 @@ final class RetrospectManager: RetrospectManageable {
     }
 }
 
+// MARK: - MessageManagerListener conformance
+
 extension RetrospectManager: MessageManagerListener {
-    func didFinishRetrospect(_ messageManager: MessageManager) {
-        guard let index = retrospects
-            .firstIndex(where: { $0.id == messageManager.retrospectID })
+    func didFinishRetrospect(_ messageManager: MessageManageable) {
+        guard let index = retrospects.firstIndex(where: { $0.id == messageManager.retrospectID })
         else { return }
-        retrospects[index].status = .finish
+        
+        retrospects[index].status = .finished
     }
     
-    func didChangeStatus(_ messageManager: MessageManager, to status: Retrospect.Status) {
-        guard let index = retrospects
-            .firstIndex(where: { $0.id == messageManager.retrospectID })
+    func didChangeStatus(_ messageManager: MessageManageable, to status: Retrospect.Status) {
+        guard let index = retrospects.firstIndex(where: { $0.id == messageManager.retrospectID })
         else { return }
+        
         retrospects[index].status = status
     }
 }

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -41,7 +41,7 @@ extension RetrospectManager: MessageManagerListener {
         retrospects[index].status = .finish
     }
     
-    func didChangStatus(_ messageManager: MessageManager, to status: Retrospect.Status) {
+    func didChangeStatus(_ messageManager: MessageManager, to status: Retrospect.Status) {
         guard let index = retrospects
             .firstIndex(where: { $0.id == messageManager.retrospectID })
         else { return }

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -32,3 +32,19 @@ final class RetrospectManager: RetrospectManageable {
         
     }
 }
+
+extension RetrospectManager: MessageManagerListener {
+    func didFinishRetrospect(_ messageManager: MessageManager) {
+        guard let index = retrospects
+            .firstIndex(where: { $0.id == messageManager.retrospectID })
+        else { return }
+        retrospects[index].status = .finish
+    }
+    
+    func didChangStatus(_ messageManager: MessageManager, to status: Retrospect.Status) {
+        guard let index = retrospects
+            .firstIndex(where: { $0.id == messageManager.retrospectID })
+        else { return }
+        retrospects[index].status = status
+    }
+}

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -9,7 +9,6 @@ import Foundation
 
 final class RetrospectManager: RetrospectManageable {
     private(set) var retrospects: [Retrospect] = []
-    
     fileprivate var messageMap: [UUID: MessageManageable] = [:]
     
     func fetchRetrospects(offset: Int, mount: Int) {

--- a/RetsTalk/RetsTalk/User/Controller/UserViewController.swift
+++ b/RetsTalk/RetsTalk/User/Controller/UserViewController.swift
@@ -1,0 +1,6 @@
+//
+//  UserViewController.swift
+//  RetsTalk
+//
+//  Created by KimMinSeok on 11/19/24.
+//

--- a/RetsTalk/RetsTalk/User/Model/User.swift
+++ b/RetsTalk/RetsTalk/User/Model/User.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 struct User {
-        let id: UUID = UUID()
-        let nickname: String
+    let id: UUID = UUID()
+    let nickname: String
 }

--- a/RetsTalk/RetsTalk/User/Model/User.swift
+++ b/RetsTalk/RetsTalk/User/Model/User.swift
@@ -1,0 +1,13 @@
+//
+//  User.swift
+//  RetsTalk
+//
+//  Created by KimMinSeok on 11/19/24.
+//
+
+import Foundation
+
+struct User {
+        let id: UUID = UUID()
+        let nickname: String
+}


### PR DESCRIPTION
##  📌 관련 이슈

- closed: #53 

## ✨ 세부 내용
테스트를 위해서 Model Entity 구현
### 회고와 메시지 관리자 구현체 구성
- 회고 부분에 Create 임시 구현
- 나머지 관리자 부분의 세부 구현은 다른 PR에서 예정입니다.

### 회고와 메시지 관리자를 연결하는 Delegate 구현
- 상태 변경을 하는 Method 구현
- 회고 종료를 하는 Method 구현

<!-- 수정/추가한 내용을 적어주세요. -->

## ✍️ 고민한 내용
### 회고 종료를 한다고 해서 삭제가 되지 않음
현재 두개의 함수로 분리를 해줬는데 필요할까 생각해봐야겠네요
```swift
func didFinishRetrospect(_ messageManager: MessageManager) {
    guard let index = retrospects
        .firstIndex(where: { $0.id == messageManager.retrospectID })
    else { return }
    retrospects[index].status = .finish
}

func didChangStatus(_ messageManager: MessageManager, to status: Retrospect.Status) {
    guard let index = retrospects
        .firstIndex(where: { $0.id == messageManager.retrospectID })
    else { return }
    retrospects[index].status = status
}
```

<!-- 해당 PR중 고민한 내용이 있으면 적어주세요. -->

## ⌛ 소요 시간
2h