### PR TITLE
회고 목록 화면: 셀, 테이블뷰 UI 구현

### DIFF
--- a/RetsTalk/RetsTalk.xcodeproj/project.pbxproj
+++ b/RetsTalk/RetsTalk.xcodeproj/project.pbxproj
@@ -47,7 +47,6 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
-				Retrospect/View/Cell/RetrospectCell.swift,
 			);
 			target = 21759C3A2CD8AE0D0033EA52 /* RetsTalk */;
 		};

--- a/RetsTalk/RetsTalk.xcodeproj/project.pbxproj
+++ b/RetsTalk/RetsTalk.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 				Persistent/EntityRepresentable.swift,
 				Persistent/Persistable.swift,
 				Persistent/PersistFetchRequestable.swift,
+				"Utility/Extensions/Collection+Extension.swift",
 			);
 			target = D5EEA5F02CEC32A600090456 /* PersistTests */;
 		};

--- a/RetsTalk/RetsTalk/Chat/Model/AssistantMessageProvider.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/AssistantMessageProvider.swift
@@ -1,0 +1,10 @@
+//
+//  AssistantMessageProvider.swift
+//  RetsTalk
+//
+//  Created on 11/19/24.
+//
+
+protocol AssistantMessageProvider {
+    func requestAssistantMessage(for chat: [Message]) async throws -> Message
+}

--- a/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectViewController.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectViewController.swift
@@ -6,23 +6,86 @@
 //
 
 import UIKit
+import SwiftUI
 
 final class RetrospectListViewController: UIViewController {
+    let retrospectListView = RetrospectListView()
+    
+    private let dataSource = [
+        ("해야할 일의 절반밖에 못했지만, 속도보다 방향이 더 중요하다는 걸 배운 날이었다.", Date()),
+        ("회고의 중요성을 깨닫고, 혼자만이 아닌 함께 성장하기 위해 남은 시간 동안 성실히 임할 것을 다짐.", Date()),
+        ("계획을 계속 수정했지만, 그 과정 속에서 나의 우선순위를 다시 생각해볼 수 있었다.", Date()),
+        ("혼자서는 막막했던 문제도 함께 고민하니 쉽게 풀리며, 협업의 힘을 실감한 하루였다.", Date()),
+        ("코드 리뷰를 통해 생각지도 못한 개선점을 알게 되었고, 내 자신을 돌아볼 수 있는 계기가 되었다.", Date()),
+        ("해야할 일의 절반밖에 못했지만, 속도보다 방향이 더 중요하다는 걸 배운 날이었다.", Date()),
+        ("회고의 중요성을 깨닫고, 혼자만이 아닌 함께 성장하기 위해 남은 시간 동안 성실히 임할 것을 다짐.", Date()),
+        ("계획을 계속 수정했지만, 그 과정 속에서 나의 우선순위를 다시 생각해볼 수 있었다.", Date()),
+        ("혼자서는 막막했던 문제도 함께 고민하니 쉽게 풀리며, 협업의 힘을 실감한 하루였다.", Date()),
+        ("코드 리뷰를 통해 생각지도 못한 개선점을 알게 되었고, 내 자신을 돌아볼 수 있는 계기가 되었다.", Date()),
+    ]
     
     // MARK: ViewController lifecycle method
-
+    
+    override func loadView() {
+        view = retrospectListView
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         view.backgroundColor = .backgroundMain // 임시 배경색 설정
         setUpNavigationBar()
+        retrospectListView.setTableViewDelegate(self)
     }
     
     // MARK: Custom method
-
+    
     private func setUpNavigationBar() {
         title = Texts.titleLabelText
         navigationController?.navigationBar.prefersLargeTitles = true
+    }
+}
+
+// MARK: - UITableViewDelegate, UITableViewDataSource conformance
+
+extension RetrospectListViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return dataSource.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let data = dataSource[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: Texts.cellIdentifier, for: indexPath)
+        
+        cell.backgroundColor = .clear
+        cell.contentConfiguration = UIHostingConfiguration {
+            RetrospectCell(summary: data.0, createdAt: data.1)
+        }
+        .margins(.vertical, 4)
+        
+        return cell
+    }
+    
+    // MARK: Section 임시 생성 코드
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return "11월"
+    }
+    
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 36
+    }
+    
+    func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        if let header = view as? UITableViewHeaderFooterView {
+            header.textLabel?.font = UIFont.boldSystemFont(ofSize: 24)
+            header.textLabel?.textColor = UIColor.black
+            header.contentView.backgroundColor = .clear
+        }
     }
 }
 
@@ -30,6 +93,7 @@ final class RetrospectListViewController: UIViewController {
 
 extension RetrospectListViewController {
     enum Texts {
+        static let cellIdentifier = "RetrospectCell"
         static let titleLabelText = "회고"
     }
 }

--- a/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectViewController.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectViewController.swift
@@ -55,13 +55,13 @@ extension RetrospectListViewController: UITableViewDelegate, UITableViewDataSour
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let data = dataSource[indexPath.row]
-        let cell = tableView.dequeueReusableCell(withIdentifier: Texts.cellIdentifier, for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: Constants.retrospectCellIdentifier, for: indexPath)
         
         cell.backgroundColor = .clear
         cell.contentConfiguration = UIHostingConfiguration {
             RetrospectCell(summary: data.0, createdAt: data.1)
         }
-        .margins(.vertical, 4)
+        .margins(.vertical, Metrics.cellVerticalMargin)
         
         return cell
     }
@@ -69,20 +69,20 @@ extension RetrospectListViewController: UITableViewDelegate, UITableViewDataSour
     // MARK: Section 임시 생성 코드
     
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
+        1
     }
     
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return "11월"
+        "11월"
     }
     
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 36
+        Metrics.tableViewHeaderHeight
     }
     
     func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
         if let header = view as? UITableViewHeaderFooterView {
-            header.textLabel?.font = UIFont.boldSystemFont(ofSize: 24)
+            header.textLabel?.font = UIFont.appFont(.heavyTitle)
             header.textLabel?.textColor = UIColor.black
             header.contentView.backgroundColor = .clear
         }
@@ -91,9 +91,13 @@ extension RetrospectListViewController: UITableViewDelegate, UITableViewDataSour
 
 // MARK: - Constants
 
-extension RetrospectListViewController {
+private extension RetrospectListViewController {
+    enum Metrics {
+        static let cellVerticalMargin = 4.0
+        static let tableViewHeaderHeight = 36.0
+    }
+    
     enum Texts {
-        static let cellIdentifier = "RetrospectCell"
         static let titleLabelText = "회고"
     }
 }

--- a/RetsTalk/RetsTalk/Retrospect/View/Cell/RetrospectCell.swift
+++ b/RetsTalk/RetsTalk/Retrospect/View/Cell/RetrospectCell.swift
@@ -94,7 +94,6 @@ struct RetrospectView_Previews: PreviewProvider {
         ZStack {
             Color("BackgroundMain").edgesIgnoringSafeArea(.all)
             VStack {
-                RetrospectCell(summary: "디버깅에 너무너무 지친 하루였지만, 원인을 찾고 문제를 해결하면서 더 단단해진 뭐 그런 기분이다. 최대한 길이를 길게 써보려고 함", createdAt: Date())
                 RetrospectCell(summary: "디버깅에 지친 하루이다.", createdAt: Date())
                 RetrospectCell(summary: "디버깅에 지친 하루였지만, 원인을 찾고 문제를 해결하면서 조금 더 단단해진 기분이다.", createdAt: Date())
             }

--- a/RetsTalk/RetsTalk/Retrospect/View/Cell/RetrospectCell.swift
+++ b/RetsTalk/RetsTalk/Retrospect/View/Cell/RetrospectCell.swift
@@ -40,7 +40,7 @@ private extension RetrospectCell {
                     .truncationMode(.tail)
                 Spacer()
             }
-            .frame(height: 40, alignment: .topLeading)
+            .frame(height: Numerics.summaryTextHeight, alignment: .topLeading)
         }
     }
     
@@ -52,29 +52,14 @@ private extension RetrospectCell {
         }
         
         var body: some View {
-            Text(formatDateToKoreanStyle(date: date))
+            Text(date.formattedToKoreanStyle)
                 .font(Font(UIFont.appFont(.caption)))
                 .foregroundStyle(.blueBerry)
         }
         
-        private func formatDateToKoreanStyle(date: Date) -> String {
-            let calendar = Calendar.current
-            let dateFormatter = DateFormatter()
-            dateFormatter.locale = Locale(identifier: Texts.dateLocaleIdentifier)
-            
-            switch date {
-            case _ where calendar.isDateInToday(date):
-                dateFormatter.dateFormat = Texts.dateFormatRecent
-                return dateFormatter.string(from: date)
-            case _ where calendar.isDateInYesterday(date):
-                return Texts.dateFormatYesterday
-            default:
-                dateFormatter.dateFormat = Texts.dateFormat
-                return dateFormatter.string(from: date)
-            }
         }
     }
-}
+
 
 // MARK: - Constants
 
@@ -88,18 +73,16 @@ private extension RetrospectCell {
     
     enum Numerics {
         static let summaryTextLineLimit = 2
+        static let summaryTextHeight = 40.0
     }
     
     enum Texts {
         static let cellBackgroundColorName = "BackgroundRetrospect"
         static let cellStrokeColorName = "StrokeRetrospect"
-        
-        static let dateLocaleIdentifier = "ko_KR"
-        static let dateFormat = "M월 d일 EEEE"
-        static let dateFormatRecent = "오늘 a h:mm"
-        static let dateFormatYesterday = "어제"
     }
 }
+
+// MARK: - Preview
 
 struct RetrospectView_Previews: PreviewProvider {
     static var previews: some View {

--- a/RetsTalk/RetsTalk/Retrospect/View/Cell/RetrospectCell.swift
+++ b/RetsTalk/RetsTalk/Retrospect/View/Cell/RetrospectCell.swift
@@ -58,10 +58,20 @@ private extension RetrospectCell {
         }
         
         private func formatDateToKoreanStyle(date: Date) -> String {
+            let calendar = Calendar.current
             let dateFormatter = DateFormatter()
             dateFormatter.locale = Locale(identifier: Texts.dateLocaleIdentifier)
-            dateFormatter.dateFormat = Texts.dateFormat
-            return dateFormatter.string(from: date)
+            
+            switch date {
+            case _ where calendar.isDateInToday(date):
+                dateFormatter.dateFormat = Texts.dateFormatRecent
+                return dateFormatter.string(from: date)
+            case _ where calendar.isDateInYesterday(date):
+                return Texts.dateFormatYesterday
+            default:
+                dateFormatter.dateFormat = Texts.dateFormat
+                return dateFormatter.string(from: date)
+            }
         }
     }
 }
@@ -84,8 +94,10 @@ private extension RetrospectCell {
         static let cellBackgroundColorName = "BackgroundRetrospect"
         static let cellStrokeColorName = "StrokeRetrospect"
         
-        static let dateFormat = "M월 d일 EEEE"
         static let dateLocaleIdentifier = "ko_KR"
+        static let dateFormat = "M월 d일 EEEE"
+        static let dateFormatRecent = "오늘 a h:mm"
+        static let dateFormatYesterday = "어제"
     }
 }
 

--- a/RetsTalk/RetsTalk/Retrospect/View/Cell/RetrospectCell.swift
+++ b/RetsTalk/RetsTalk/Retrospect/View/Cell/RetrospectCell.swift
@@ -1,1 +1,103 @@
+import SwiftUI
 
+struct RetrospectCell: View {
+    let summary: String
+    let createdAt: Date
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            SummaryText(summary)
+            Spacer()
+                .frame(height: Metrics.padding)
+            CreatedDateText(createdAt)
+        }
+        .padding(Metrics.padding)
+        .background(Color(Texts.cellBackgroundColorName))
+        .cornerRadius(Metrics.cornerRadius)
+        .overlay(
+            RoundedRectangle(cornerRadius: Metrics.cornerRadius)
+                .stroke(Color(Texts.cellStrokeColorName), lineWidth: Metrics.RectangleStrokeWidth)
+        )
+        .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - Subviews
+
+private extension RetrospectCell {
+    struct SummaryText: View {
+        let content: String
+        
+        init(_ content: String) {
+            self.content = content
+        }
+    
+        var body: some View {
+            HStack(alignment: .top) {
+                Text(content.charWrapping)
+                    .font(Font(UIFont.appFont(.semiTitle)))
+                    .lineLimit(Numerics.summaryTextLineLimit)
+                    .truncationMode(.tail)
+                Spacer()
+            }
+            .frame(height: 40, alignment: .topLeading)
+        }
+    }
+    
+    struct CreatedDateText: View {
+        let date: Date
+        
+        init(_ date: Date) {
+            self.date = date
+        }
+        
+        var body: some View {
+            Text(formatDateToKoreanStyle(date: date))
+                .font(Font(UIFont.appFont(.caption)))
+                .foregroundStyle(.blueBerry)
+        }
+        
+        private func formatDateToKoreanStyle(date: Date) -> String {
+            let dateFormatter = DateFormatter()
+            dateFormatter.locale = Locale(identifier: Texts.dateLocaleIdentifier)
+            dateFormatter.dateFormat = Texts.dateFormat
+            return dateFormatter.string(from: date)
+        }
+    }
+}
+
+// MARK: - Constants
+
+private extension RetrospectCell {
+    enum Metrics {
+        static let margin = 16.0
+        static let padding = 10.0
+        static let cornerRadius = 12.0
+        static let RectangleStrokeWidth = 1.0
+    }
+    
+    enum Numerics {
+        static let summaryTextLineLimit = 2
+    }
+    
+    enum Texts {
+        static let cellBackgroundColorName = "BackgroundRetrospect"
+        static let cellStrokeColorName = "StrokeRetrospect"
+        
+        static let dateFormat = "M월 d일 EEEE"
+        static let dateLocaleIdentifier = "ko_KR"
+    }
+}
+
+struct RetrospectView_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            Color("BackgroundMain").edgesIgnoringSafeArea(.all)
+            VStack {
+                RetrospectCell(summary: "디버깅에 너무너무 지친 하루였지만, 원인을 찾고 문제를 해결하면서 더 단단해진 뭐 그런 기분이다. 최대한 길이를 길게 써보려고 함", createdAt: Date())
+                RetrospectCell(summary: "디버깅에 지친 하루이다.", createdAt: Date())
+                RetrospectCell(summary: "디버깅에 지친 하루였지만, 원인을 찾고 문제를 해결하면서 조금 더 단단해진 기분이다.", createdAt: Date())
+            }
+        }
+    }
+}

--- a/RetsTalk/RetsTalk/Retrospect/View/RetrospectView.swift
+++ b/RetsTalk/RetsTalk/Retrospect/View/RetrospectView.swift
@@ -17,7 +17,7 @@ final class RetrospectListView: UIView {
         tableView.backgroundColor = .backgroundMain
         tableView.allowsSelection = false
         tableView.rowHeight = UITableView.automaticDimension
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "RetrospectCell")
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: Constants.retrospectCellIdentifier)
         return tableView
     }()
     

--- a/RetsTalk/RetsTalk/Retrospect/View/RetrospectView.swift
+++ b/RetsTalk/RetsTalk/Retrospect/View/RetrospectView.swift
@@ -9,4 +9,48 @@ import UIKit
 
 final class RetrospectListView: UIView {
     
+    // MARK: UI components
+
+    let retrospectListTableView: UITableView = {
+        let tableView = UITableView()
+        tableView.separatorStyle = .none
+        tableView.backgroundColor = .backgroundMain
+        tableView.allowsSelection = false
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "RetrospectCell")
+        return tableView
+    }()
+    
+    // MARK: Init method
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUpTableViewLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        setUpTableViewLayout()
+    }
+    
+    // MARK: Custom Method
+    
+    private func setUpTableViewLayout() {
+        addSubview(retrospectListTableView)
+        retrospectListTableView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            retrospectListTableView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            retrospectListTableView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            retrospectListTableView.leftAnchor.constraint(equalTo: leftAnchor),
+            retrospectListTableView.rightAnchor.constraint(equalTo: rightAnchor),
+        ])
+    }
+    
+    func setTableViewDelegate(_ delegate: UITableViewDelegate & UITableViewDataSource) {
+        retrospectListTableView.delegate = delegate
+        retrospectListTableView.dataSource = delegate
+    }
 }

--- a/RetsTalk/RetsTalk/Utility/Enums/Constants.swift
+++ b/RetsTalk/RetsTalk/Utility/Enums/Constants.swift
@@ -1,0 +1,16 @@
+//
+//  Constants.swift
+//  RetsTalk
+//
+//  Created by HanSeung on 11/21/24.
+//
+
+enum Constants {
+    static let retrospectCellIdentifier = "RetrospectCell"
+    static let messageCellIdentifier = "MessageCell"
+    
+    static let dateLocaleIdentifier = "ko_KR"
+    static let dateFormat = "M월 d일 EEEE"
+    static let dateFormatRecent = "오늘 a h:mm"
+    static let dateFormatYesterday = "어제"
+}

--- a/RetsTalk/RetsTalk/Utility/Extensions/Date+Extension.swift
+++ b/RetsTalk/RetsTalk/Utility/Extensions/Date+Extension.swift
@@ -1,0 +1,27 @@
+//
+//  Date+Extension.swift
+//  RetsTalk
+//
+//  Created by HanSeung on 11/21/24.
+//
+
+import Foundation
+
+extension Date {
+    var formattedToKoreanStyle: String {
+        let calendar = Calendar.current
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: Constants.dateLocaleIdentifier)
+        
+        switch self {
+        case _ where calendar.isDateInToday(self):
+            dateFormatter.dateFormat = Constants.dateFormatRecent
+            return dateFormatter.string(from: self)
+        case _ where calendar.isDateInYesterday(self):
+            return Constants.dateFormatYesterday
+        default:
+            dateFormatter.dateFormat = Constants.dateFormat
+            return dateFormatter.string(from: self)
+        }
+    }
+}

--- a/RetsTalk/RetsTalk/Utility/Extensions/String+Extension.swift
+++ b/RetsTalk/RetsTalk/Utility/Extensions/String+Extension.swift
@@ -1,0 +1,12 @@
+//
+//  String+Extension.swift
+//  RetsTalk
+//
+//  Created by HanSeung on 11/20/24.
+//
+
+extension String {
+    var charWrapping: String {
+        return String(self.reduce("") { $0 + String($1) + "\u{200B}" }.dropLast())
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #68 
- closed: #73 

## ✨ 세부 내용
회고목록 화면을 구성하는 셀과 테이블뷰에 대한 UI를 구현했습니다.

### 동작화면
| iPhone 16 Pro | iPhone SE (3rd generation) |
|---|---|
|<img src="https://github.com/user-attachments/assets/160d35df-db66-4869-a698-df953fcb0f9d" width="250"/>|<img src="https://github.com/user-attachments/assets/b83ceab3-d75b-4197-983a-e9cfa7231422" width="250"/>|






## ✍️ 고민한 내용

<!-- 해당 PR중 고민한 내용이 있으면 적어주세요. -->

## ⌛ 소요 시간
2H