### PR TITLE
MessageManageable의 구체타입 구현(Fetch 부분)

### DIFF
--- a/RetsTalk/RetsTalk.xcodeproj/project.pbxproj
+++ b/RetsTalk/RetsTalk.xcodeproj/project.pbxproj
@@ -44,6 +44,21 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		12A2A34F2CED8570007E083C /* Exceptions for "RetsTalk" folder in "RetsTalkTests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Chat/Model/Message.swift,
+				Chat/Model/MessageManageable.swift,
+				Chat/Model/MessageManager.swift,
+				Chat/Model/MessageManagerListener.swift,
+				Persistent/EntityRepresentable.swift,
+				Persistent/Persistable.swift,
+				Persistent/PersistFetchRequestable.swift,
+				Retrospect/Model/Retrospect.swift,
+				User/Model/User.swift,
+			);
+			target = 21759C532CD8AE0F0033EA52 /* RetsTalkTests */;
+		};
 		21759C662CD8AE0F0033EA52 /* Exceptions for "RetsTalk" folder in "RetsTalk" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -72,6 +87,7 @@
 				Persistent/Implementation/CoreDataManager.swift,
 				Persistent/Persistable.swift,
 				Persistent/PersistFetchRequestable.swift,
+				"Utility/Extensions/Collection+Extension.swift",
 			);
 			target = D5EEA5F02CEC32A600090456 /* PersistTests */;
 		};
@@ -100,6 +116,7 @@
 			exceptions = (
 				21759C662CD8AE0F0033EA52 /* Exceptions for "RetsTalk" folder in "RetsTalk" target */,
 				12A29F122CEB652D007E083C /* Exceptions for "RetsTalk" folder in "Copy Bundle Resources" phase from "RetsTalk" target */,
+				12A2A34F2CED8570007E083C /* Exceptions for "RetsTalk" folder in "RetsTalkTests" target */,
 				D59E35E42CD9F389001B6D5A /* Exceptions for "RetsTalk" folder in "NetworkTests" target */,
 				D5EEA6022CEC32BE00090456 /* Exceptions for "RetsTalk" folder in "PersistTests" target */,
 			);

--- a/RetsTalk/RetsTalk.xcodeproj/project.pbxproj
+++ b/RetsTalk/RetsTalk.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Persistent/EntityRepresentable.swift,
+				Persistent/Implementation/CoreDataManager.swift,
 				Persistent/Persistable.swift,
 				Persistent/PersistFetchRequestable.swift,
 				"Utility/Extensions/Collection+Extension.swift",

--- a/RetsTalk/RetsTalk/Chat/Model/Message.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/Message.swift
@@ -17,3 +17,23 @@ struct Message {
         case assistant
     }
 }
+
+// MARK: - EntityRepresentable
+
+extension Message: EntityRepresentable {
+    var mappingDictionary: [String: Any] {
+        [
+            "role": role,
+            "content": content,
+            "createdAt": createdAt,
+        ]
+    }
+    
+    init(dictionary: [String: Any]) {
+        role = dictionary["role"] as? Role ?? .user
+        content = dictionary["content"] as? String ?? ""
+        createdAt = dictionary["createdAt"] as? Date ?? Date()
+    }
+    
+    static let entityName = "Message"
+}

--- a/RetsTalk/RetsTalk/Chat/Model/Message.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/Message.swift
@@ -35,5 +35,5 @@ extension Message: EntityRepresentable {
         createdAt = dictionary["createdAt"] as? Date ?? Date()
     }
     
-    static let entityName = "Message"
+    static let entityName = "MessageEntity"
 }

--- a/RetsTalk/RetsTalk/Chat/Model/MessageManageable.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/MessageManageable.swift
@@ -12,7 +12,7 @@ protocol MessageManageable {
     var messages: [Message] { get }
     var messageManagerListener: MessageManagerListener { get }
     
-    func fetchMessages(offset: Int, amount: Int)
+    func fetchMessages(offset: Int, amount: Int) async throws
     func send(_ message: Message)
     func endRetrospect()
 }

--- a/RetsTalk/RetsTalk/Chat/Model/MessageManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/MessageManager.swift
@@ -23,8 +23,18 @@ final class MessageManager: MessageManageable {
         self.persistent = persistent
     }
     
-    func fetchMessages(offset: Int, amount: Int) {
+    func fetchMessages(offset: Int, amount: Int) async throws {
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            NSPredicate(format: "retrospectID = %@", argumentArray: [retrospectID]),
+        ])
+        let request = PersistfetchRequest<Message>(
+            predicate: predicate,
+            fetchLimit: amount,
+            fetchOffset: offset
+        )
+        let fetchedEntities = try await persistent.fetch(by: request)
         
+        messages.append(contentsOf: fetchedEntities)
     }
     
     func send(_ message: Message) {

--- a/RetsTalk/RetsTalk/Chat/Model/MessageManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/MessageManager.swift
@@ -9,7 +9,7 @@ import Foundation
 
 final class MessageManager: MessageManageable {
     let retrospectID: UUID
-    private(set) var messages: [Message] = []
+    @Published private(set) var messages: [Message] = []
     private(set) var messageManagerListener: MessageManagerListener
     let persistent: Persistable
     
@@ -24,14 +24,15 @@ final class MessageManager: MessageManageable {
     }
     
     func fetchMessages(offset: Int, amount: Int) async throws {
-        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-            NSPredicate(format: "retrospectID = %@", argumentArray: [retrospectID]),
-        ])
+        let predicate = NSPredicate(format: "retrospectID = %@", argumentArray: [retrospectID])
+        let sortDescriptor = NSSortDescriptor(key: "createdAt", ascending: false)
         let request = PersistfetchRequest<Message>(
             predicate: predicate,
+            sortDescriptors: [sortDescriptor],
             fetchLimit: amount,
             fetchOffset: offset
         )
+        
         let fetchedEntities = try await persistent.fetch(by: request)
         
         messages.append(contentsOf: fetchedEntities)

--- a/RetsTalk/RetsTalk/Chat/Model/MessageManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/MessageManager.swift
@@ -11,10 +11,16 @@ final class MessageManager: MessageManageable {
     let retrospectID: UUID
     private(set) var messages: [Message] = []
     private(set) var messageManagerListener: MessageManagerListener
+    let persistent: Persistable
     
-    init(retrospectID: UUID, messageManagerListener: MessageManagerListener) {
+    init(
+        retrospectID: UUID,
+        messageManagerListener: MessageManagerListener,
+        persistent: Persistable
+    ) {
         self.retrospectID = retrospectID
         self.messageManagerListener = messageManagerListener
+        self.persistent = persistent
     }
     
     func fetchMessages(offset: Int, amount: Int) {

--- a/RetsTalk/RetsTalk/Chat/Model/MessageManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/MessageManager.swift
@@ -25,7 +25,7 @@ final class MessageManager: MessageManageable {
     
     func fetchMessages(offset: Int, amount: Int) async throws {
         let predicate = NSPredicate(format: "retrospectID = %@", argumentArray: [retrospectSubject.value.id])
-        let sortDescriptor = NSSortDescriptor(key: "createdAt", ascending: false)
+        let sortDescriptor = NSSortDescriptor(key: "createdAt", ascending: true)
         let request = PersistfetchRequest<Message>(
             predicate: predicate,
             sortDescriptors: [sortDescriptor],

--- a/RetsTalk/RetsTalk/Chat/Model/MessageManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/MessageManager.swift
@@ -9,7 +9,10 @@ import Foundation
 import Combine
 
 final class MessageManager: MessageManageable {
-    var retrospectSubject: CurrentValueSubject<Retrospect, Never>
+    private var retrospect: Retrospect {
+        didSet { retrospectSubject.send(retrospect) }
+    }
+    private(set) var retrospectSubject: CurrentValueSubject<Retrospect, Never>
     private(set) var messageManagerListener: MessageManagerListener
     let persistent: Persistable
 
@@ -18,13 +21,14 @@ final class MessageManager: MessageManageable {
         messageManagerListener: MessageManagerListener,
         persistent: Persistable
     ) {
+        self.retrospect = retrospect
         self.retrospectSubject = CurrentValueSubject(retrospect)
         self.messageManagerListener = messageManagerListener
         self.persistent = persistent
     }
     
     func fetchMessages(offset: Int, amount: Int) async throws {
-        let predicate = NSPredicate(format: "retrospectID = %@", argumentArray: [retrospectSubject.value.id])
+        let predicate = NSPredicate(format: "retrospectID = %@", argumentArray: [retrospect.id])
         let sortDescriptor = NSSortDescriptor(key: "createdAt", ascending: true)
         let request = PersistfetchRequest<Message>(
             predicate: predicate,
@@ -35,7 +39,7 @@ final class MessageManager: MessageManageable {
         
         let fetchedEntities = try await persistent.fetch(by: request)
         
-        retrospectSubject.value.chat.append(contentsOf: fetchedEntities)
+        retrospect.chat.append(contentsOf: fetchedEntities)
     }
     
     func send(_ message: Message) async throws {

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -19,7 +19,8 @@ final class RetrospectManager: RetrospectManageable {
         let retropsect = Retrospect(user: User(nickname: "alstjr"))
         let messageManager = MessageManager(
             retrospect: retropsect,
-            messageManagerListener: self
+            messageManagerListener: self,
+            persistent: CoreDataManager(name: "RetsTalk", completion: { _ in })
         )
         
         retrospects.append(retropsect)

--- a/RetsTalk/RetsTalk/User/Controller/UserViewController.swift
+++ b/RetsTalk/RetsTalk/User/Controller/UserViewController.swift
@@ -4,3 +4,9 @@
 //
 //  Created by KimMinSeok on 11/19/24.
 //
+
+import UIKit
+
+final class UserViewController: UIViewController {
+    
+}

--- a/RetsTalk/RetsTalkTests/MessageManagerTests.swift
+++ b/RetsTalk/RetsTalkTests/MessageManagerTests.swift
@@ -73,11 +73,12 @@ final class MessageManagerTests: XCTestCase {
     func test_fetchMessage_데이터를_순서대로_불러오는가() async throws {
         let messageManager = try XCTUnwrap(messageManager)
         
-        testableMessages.sort { $0.createdAt > $1.createdAt }
+        testableMessages.sort { $0.createdAt < $1.createdAt }
         try await messageManager.fetchMessages(offset: 0, amount: testableMessages.count)
         
         let messageResult = messageManager.retrospectSubject.value.chat
         for (index, testMessage) in testableMessages.enumerated() {
+            print(testMessage.content)
             XCTAssertEqual(messageResult[index].content, testMessage.content)
             XCTAssertEqual(messageResult[index].createdAt, testMessage.createdAt)
         }

--- a/RetsTalk/RetsTalkTests/MessageManagerTests.swift
+++ b/RetsTalk/RetsTalkTests/MessageManagerTests.swift
@@ -23,9 +23,9 @@ final class MessageManagerTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-                
+        
         messageManager = MessageManager(
-            retrospectID: UUID(),
+            retrospect: Retrospect(user: User(nickname: "testUser")),
             messageManagerListener: MockRetrospectManager(),
             persistent: MockMessageStore(messages: testableMessages)
         )
@@ -38,7 +38,8 @@ final class MessageManagerTests: XCTestCase {
         
         try await messageManager.fetchMessages(offset: 0, amount: 2)
         
-        XCTAssertEqual(messageManager.messages.count, 2)
+        let messageResult = messageManager.retrospectSubject.value.chat
+        XCTAssertEqual(messageResult.count, 2)
     }
     
     func test_fetchMessage_많은_메시지를_불러오는가() async throws {
@@ -46,7 +47,8 @@ final class MessageManagerTests: XCTestCase {
         
         try await messageManager.fetchMessages(offset: 0, amount: 5)
         
-        XCTAssertEqual(messageManager.messages.count, 5)
+        let messageResult = messageManager.retrospectSubject.value.chat
+        XCTAssertEqual(messageResult.count, 5)
     }
     
     func test_fetchMessage_가지고_있는_부분보다_많은_메시지를_요청하면_최대까지만_불러오는가() async throws {
@@ -54,7 +56,8 @@ final class MessageManagerTests: XCTestCase {
         
         try await messageManager.fetchMessages(offset: 0, amount: 10)
         
-        XCTAssertEqual(messageManager.messages.count, 7)
+        let messageResult = messageManager.retrospectSubject.value.chat
+        XCTAssertEqual(messageResult.count, 7)
     }
     
     func test_fetchMessage_데이터를_추가로_불러올_수_있는가() async throws {
@@ -63,7 +66,8 @@ final class MessageManagerTests: XCTestCase {
         try await messageManager.fetchMessages(offset: 0, amount: 2)
         try await messageManager.fetchMessages(offset: 2, amount: 2)
         
-        XCTAssertEqual(messageManager.messages.count, 4)
+        let messageResult = messageManager.retrospectSubject.value.chat
+        XCTAssertEqual(messageResult.count, 4)
     }
     
     func test_fetchMessage_데이터를_순서대로_불러오는가() async throws {

--- a/RetsTalk/RetsTalkTests/MessageManagerTests.swift
+++ b/RetsTalk/RetsTalkTests/MessageManagerTests.swift
@@ -83,4 +83,14 @@ final class MessageManagerTests: XCTestCase {
             XCTAssertEqual(messageResult[index].createdAt, testMessage.createdAt)
         }
     }
+    
+    func test_fetchMessage_제일_최신에_있는_데이터를_불러오는가() async throws {
+        let messageManager = try XCTUnwrap(messageManager)
+        
+        try await messageManager.fetchMessages(offset: 0, amount: 2)
+        
+        let messageResult = messageManager.retrospectSubject.value.chat
+        XCTAssertEqual(messageResult.first?.content, "Hello")
+        XCTAssertEqual(messageResult.last?.content, "영어를 했어요")
+    }
 }

--- a/RetsTalk/RetsTalkTests/MessageManagerTests.swift
+++ b/RetsTalk/RetsTalkTests/MessageManagerTests.swift
@@ -73,9 +73,13 @@ final class MessageManagerTests: XCTestCase {
     func test_fetchMessage_데이터를_순서대로_불러오는가() async throws {
         let messageManager = try XCTUnwrap(messageManager)
         
-        try await messageManager.fetchMessages(offset: 0, amount: 2)
+        testableMessages.sort { $0.createdAt > $1.createdAt }
+        try await messageManager.fetchMessages(offset: 0, amount: testableMessages.count)
         
-        XCTAssertEqual(messageManager.messages.first?.content, testableMessages[3].content)
-        XCTAssertEqual(messageManager.messages.last?.content, testableMessages[1].content)
+        let messageResult = messageManager.retrospectSubject.value.chat
+        for (index, testMessage) in testableMessages.enumerated() {
+            XCTAssertEqual(messageResult[index].content, testMessage.content)
+            XCTAssertEqual(messageResult[index].createdAt, testMessage.createdAt)
+        }
     }
 }

--- a/RetsTalk/RetsTalkTests/MessageManagerTests.swift
+++ b/RetsTalk/RetsTalkTests/MessageManagerTests.swift
@@ -1,0 +1,61 @@
+//
+//  MessageManagerTests.swift
+//  RetsTalk
+//
+//  Created by KimMinSeok on 11/20/24.
+//
+
+import XCTest
+
+final class MessageManagerTests: XCTestCase {
+    private var messageManager: MessageManageable?
+    private var testableMessages: [Message] = [
+        Message(role: .assistant, content: "오늘은 무엇을 하셨나요?", createdAt: Date() + 6),
+        Message(role: .user, content: "오늘은 공부를 했어요", createdAt: Date() + 5),
+        Message(role: .assistant, content: "무슨 공부를 하셨나요?", createdAt: Date() + 4),
+        Message(role: .user, content: "수능 공부를 했습니다.", createdAt: Date() + 3),
+        Message(role: .user, content: "무슨 과목을 하셨나요?", createdAt: Date() + 2),
+        Message(role: .user, content: "영어를 했어요", createdAt: Date() + 1),
+        Message(role: .user, content: "Hello", createdAt: Date()),
+    ]
+    
+    // MARK: Set up
+    
+    override func setUp() {
+        super.setUp()
+        
+        let persistent = MockMessageStore()
+        persistent.messages = testableMessages
+        
+        messageManager = MessageManager(
+            retrospectID: UUID(),
+            messageManagerListener: MockRetrospectManager(),
+            persistent: persistent
+        )
+    }
+    
+    func test_fetchMessage_메시지를_불러올_수_있는가() async throws {
+        let messageManager = try XCTUnwrap(messageManager)
+        
+        try await messageManager.fetchMessages(offset: 0, amount: 2)
+        
+        XCTAssertEqual(messageManager.messages.count, 2)
+    }
+    
+    func test_fetchMessage_데이터를_추가로_불러올_수_있는가() async throws {
+        let messageManager = try XCTUnwrap(messageManager)
+        
+        try await messageManager.fetchMessages(offset: 0, amount: 2)
+        try await messageManager.fetchMessages(offset: 2, amount: 2)
+        
+        XCTAssertEqual(messageManager.messages.count, 4)
+    }
+    
+    func test_fetchMessage_데이터를_순서대로_불러오는가() async throws {
+        let messageManager = try XCTUnwrap(messageManager)
+        
+        try await messageManager.fetchMessages(offset: 0, amount: 2)
+        
+        XCTAssertEqual(messageManager.messages.first?.content, "오늘은 무엇을 하셨나요?")
+    }
+}

--- a/RetsTalk/RetsTalkTests/MessageManagerTests.swift
+++ b/RetsTalk/RetsTalkTests/MessageManagerTests.swift
@@ -10,29 +10,28 @@ import XCTest
 final class MessageManagerTests: XCTestCase {
     private var messageManager: MessageManageable?
     private var testableMessages: [Message] = [
-        Message(role: .assistant, content: "오늘은 무엇을 하셨나요?", createdAt: Date() + 6),
-        Message(role: .user, content: "오늘은 공부를 했어요", createdAt: Date() + 5),
-        Message(role: .assistant, content: "무슨 공부를 하셨나요?", createdAt: Date() + 4),
         Message(role: .user, content: "수능 공부를 했습니다.", createdAt: Date() + 3),
+        Message(role: .user, content: "오늘은 공부를 했어요", createdAt: Date() + 5),
         Message(role: .user, content: "무슨 과목을 하셨나요?", createdAt: Date() + 2),
-        Message(role: .user, content: "영어를 했어요", createdAt: Date() + 1),
+        Message(role: .assistant, content: "오늘은 무엇을 하셨나요?", createdAt: Date() + 6),
+        Message(role: .assistant, content: "무슨 공부를 하셨나요?", createdAt: Date() + 4),
         Message(role: .user, content: "Hello", createdAt: Date()),
+        Message(role: .user, content: "영어를 했어요", createdAt: Date() + 1),
     ]
     
     // MARK: Set up
     
     override func setUp() {
         super.setUp()
-        
-        let persistent = MockMessageStore()
-        persistent.messages = testableMessages
-        
+                
         messageManager = MessageManager(
             retrospectID: UUID(),
             messageManagerListener: MockRetrospectManager(),
-            persistent: persistent
+            persistent: MockMessageStore(messages: testableMessages)
         )
     }
+    
+    // MARK: Test
     
     func test_fetchMessage_메시지를_불러올_수_있는가() async throws {
         let messageManager = try XCTUnwrap(messageManager)
@@ -40,6 +39,22 @@ final class MessageManagerTests: XCTestCase {
         try await messageManager.fetchMessages(offset: 0, amount: 2)
         
         XCTAssertEqual(messageManager.messages.count, 2)
+    }
+    
+    func test_fetchMessage_많은_메시지를_불러오는가() async throws {
+        let messageManager = try XCTUnwrap(messageManager)
+        
+        try await messageManager.fetchMessages(offset: 0, amount: 5)
+        
+        XCTAssertEqual(messageManager.messages.count, 5)
+    }
+    
+    func test_fetchMessage_가지고_있는_부분보다_많은_메시지를_요청하면_최대까지만_불러오는가() async throws {
+        let messageManager = try XCTUnwrap(messageManager)
+        
+        try await messageManager.fetchMessages(offset: 0, amount: 10)
+        
+        XCTAssertEqual(messageManager.messages.count, 7)
     }
     
     func test_fetchMessage_데이터를_추가로_불러올_수_있는가() async throws {
@@ -56,6 +71,7 @@ final class MessageManagerTests: XCTestCase {
         
         try await messageManager.fetchMessages(offset: 0, amount: 2)
         
-        XCTAssertEqual(messageManager.messages.first?.content, "오늘은 무엇을 하셨나요?")
+        XCTAssertEqual(messageManager.messages.first?.content, testableMessages[3].content)
+        XCTAssertEqual(messageManager.messages.last?.content, testableMessages[1].content)
     }
 }

--- a/RetsTalk/RetsTalkTests/MessageManagerTests.swift
+++ b/RetsTalk/RetsTalkTests/MessageManagerTests.swift
@@ -78,7 +78,6 @@ final class MessageManagerTests: XCTestCase {
         
         let messageResult = messageManager.retrospectSubject.value.chat
         for (index, testMessage) in testableMessages.enumerated() {
-            print(testMessage.content)
             XCTAssertEqual(messageResult[index].content, testMessage.content)
             XCTAssertEqual(messageResult[index].createdAt, testMessage.createdAt)
         }

--- a/RetsTalk/RetsTalkTests/MockMessageStore.swift
+++ b/RetsTalk/RetsTalkTests/MockMessageStore.swift
@@ -1,0 +1,56 @@
+//
+//  MockMessageStore.swift
+//  RetsTalk
+//
+//  Created by KimMinSeok on 11/20/24.
+//
+
+import Foundation
+
+final class MockMessageStore: Persistable {
+    var messages: [Message]
+    
+    init(messages: [Message]) {
+        self.messages = messages
+    }
+    
+    func add<Entity>(contentsOf entities: [Entity]) async throws -> [Entity] {
+        return entities
+    }
+    
+    func fetch<Entity>(
+        by request: any PersistFetchRequestable<Entity>
+    ) async throws -> [Entity] where Entity: EntityRepresentable {
+        let sortedMessages = messages.sorted { lhs, rhs in
+            for descriptor in request.sortDescriptors {
+                if let key = descriptor.key, key == "createdAt" {
+                    let comparisonResult = lhs.createdAt.compare(rhs.createdAt)
+                    if descriptor.ascending {
+                        return comparisonResult == .orderedAscending
+                    } else {
+                        return comparisonResult == .orderedDescending
+                    }
+                }
+            }
+            return false
+        }
+        
+        let firstIndex = request.fetchOffset
+        let lastIndex = min(request.fetchOffset + request.fetchLimit, sortedMessages.count)
+        let fetchMessages = Array(sortedMessages[firstIndex..<lastIndex])
+        
+        guard let result = fetchMessages as? [Entity] else {
+            return []
+        }
+        
+        return result
+    }
+    
+    func update<Entity>(from sourceEntity: Entity, to updatingEntity: Entity) async throws -> Entity {
+        return updatingEntity
+    }
+    
+    func delete<Entity>(contentsOf entities: [Entity]) async throws {
+        
+    }
+}

--- a/RetsTalk/RetsTalkTests/MockMessageStore.swift
+++ b/RetsTalk/RetsTalkTests/MockMessageStore.swift
@@ -21,23 +21,11 @@ final class MockMessageStore: Persistable {
     func fetch<Entity>(
         by request: any PersistFetchRequestable<Entity>
     ) async throws -> [Entity] where Entity: EntityRepresentable {
-        let sortedMessages = messages.sorted { lhs, rhs in
-            for descriptor in request.sortDescriptors {
-                if let key = descriptor.key, key == "createdAt" {
-                    let comparisonResult = lhs.createdAt.compare(rhs.createdAt)
-                    if descriptor.ascending {
-                        return comparisonResult == .orderedAscending
-                    } else {
-                        return comparisonResult == .orderedDescending
-                    }
-                }
-            }
-            return false
-        }
-        
+
+        messages.sort { $0.createdAt < $1.createdAt }
         let firstIndex = request.fetchOffset
-        let lastIndex = min(request.fetchOffset + request.fetchLimit, sortedMessages.count)
-        let fetchMessages = Array(sortedMessages[firstIndex..<lastIndex])
+        let lastIndex = min(request.fetchOffset + request.fetchLimit, messages.count)
+        let fetchMessages = Array(messages[firstIndex..<lastIndex])
         
         guard let result = fetchMessages as? [Entity] else {
             return []

--- a/RetsTalk/RetsTalkTests/MockRetrospectManager.swift
+++ b/RetsTalk/RetsTalkTests/MockRetrospectManager.swift
@@ -1,0 +1,16 @@
+//
+//  MockMessageManagerListener.swift
+//  RetsTalk
+//
+//  Created by KimMinSeok on 11/20/24.
+//
+
+final class MockRetrospectManager: MessageManagerListener {
+    func didFinishRetrospect(_ messageManager: any MessageManageable) {
+        
+    }
+    
+    func didChangeStatus(_ messageManager: any MessageManageable, to status: Retrospect.Status) {
+        
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #65 

## ✨ 세부 내용
매니저에서 Persistent에서 메시지를 가져오는 함수 구현
- 10개보다 적은 데이터가 있으면 최대까지 들고오는지?
- 2개를 받고 추가로 2개로 받는지
- 날짜순으로 정렬해서 들고오는지
- 최신 날짜의 데이터만 들고오는지

위와 같이 있는 예외들을 테스트로 잡았습니다.



<!-- 수정/추가한 내용을 적어주세요. -->

## ✍️ 고민한 내용
시간순 정렬에서 CoreData에 가면 sortDescriptors로 자동으로 하지만
Mock으로 만든 Persistent에서는 일반적인 배열을 사용해서 
sortDescriptors를 이용해 정렬을 해주기 위해서 함수로 구현해뒀습니다.

아래와 같이 구현을 했었는데

문제점: sortDescriptors를 테스트하는 것 같더라구요.,.

<details><summary>Details</summary>
<p>

```swift
func sortMessages(_ sortDescriptors: [NSSortDescriptor]) -> [Message] {
    messages.sorted { lhs, rhs in
        for descriptor in sortDescriptors {
            let key = descriptor.key
            let ascending = descriptor.ascending
            
            let comparisonResult = lhs.createdAt.compare(rhs.createdAt)
            
            return ascending
            ? comparisonResult == .orderedAscending
            : comparisonResult == .orderedDescending
        }
        return false
    }
}
```

</p>
</details> 



Test의 목적이 커지는 것 같아서 그냥 아래와 같이 직접 정렬해서
원하는 인덱스만큼만 반환하도록 해줬습니다.
```swift
messages.sort { $0.createdAt < $1.createdAt }
```

<!-- 해당 PR중 고민한 내용이 있으면 적어주세요. -->

## ⌛ 소요 시간

5h