### PR TITLE
MessageView height 버그 수정, 응답 실패시 재전송 버튼 띄우는 로직 작성, 완료된 회고 맨 위에서 보여주기 기능 추가

### DIFF
--- a/RetsTalk/RetsTalk/Chat/Controller/ChattingViewController.swift
+++ b/RetsTalk/RetsTalk/Chat/Controller/ChattingViewController.swift
@@ -124,11 +124,11 @@ final class ChattingViewController: AlertPresentableViewController {
 
         messageManager.retrospectSubject
             .receive(on: RunLoop.main)
-            .sink { [weak self] newMessages in
+            .sink { [weak self] newRetrospect in
                 guard let self = self else { return }
 
                 let oldCount = previousMessageCount
-                let newCount = newMessages.chat.filter({ !$0.content.isEmpty }).count
+                let newCount = newRetrospect.chat.filter({ !$0.content.isEmpty }).count
                 previousMessageCount = newCount
                 guard oldCount < newCount else { return }
 
@@ -140,8 +140,6 @@ final class ChattingViewController: AlertPresentableViewController {
     }
 
     @objc private func backwardButtonTapped() {
-        // navigationController: pop 작업
-        messageManager.messageManagerListener.didChangeStatus(messageManager, to: .inProgress(.waitingForUserInput))
         navigationController?.popViewController(animated: true)
     }
     
@@ -173,7 +171,7 @@ final class ChattingViewController: AlertPresentableViewController {
                 switch retrospect.status {
                 case .finished:
                     chatView.scrollToTop()
-                case .inProgress(let progressStatus):
+                case .inProgress:
                     chatView.scrollToBottom()
                 }
             } catch {

--- a/RetsTalk/RetsTalk/Chat/Controller/ChattingViewController.swift
+++ b/RetsTalk/RetsTalk/Chat/Controller/ChattingViewController.swift
@@ -177,7 +177,7 @@ final class ChattingViewController: AlertPresentableViewController {
     private func initialMessageFetch() {
         Task {
             do {
-                try await messageManager.fetchMessages(offset: Numeric.initialOffset, amount: Numeric.amount)
+                try await messageManager.fetchMessages(offset: Numerics.initialOffset, amount: Numerics.amount)
                 switch retrospect.status {
                 case .finished:
                     chatView.scrollToTop()
@@ -204,7 +204,7 @@ extension ChattingViewController: UITableViewDelegate, UITableViewDataSource {
         cell.contentConfiguration = UIHostingConfiguration {
             MessageCell(message: message.content, isUser: message.role == .user)
         }
-        .margins(.vertical, Numeric.verticalCellMargin)
+        .margins(.vertical, Numerics.verticalCellMargin)
         cell.backgroundColor = .clear
         return cell
     }
@@ -231,7 +231,7 @@ extension ChattingViewController: ChatViewDelegate {
 // MARK: - Constants
 
 private extension ChattingViewController {
-    enum Numeric {
+    enum Numerics {
         static let initialOffset = 0
         static let amount = 20
         static let verticalCellMargin = 4.0

--- a/RetsTalk/RetsTalk/Chat/Controller/ChattingViewController.swift
+++ b/RetsTalk/RetsTalk/Chat/Controller/ChattingViewController.swift
@@ -127,6 +127,16 @@ final class ChattingViewController: AlertPresentableViewController {
             .sink { [weak self] newRetrospect in
                 guard let self = self else { return }
 
+                guard newRetrospect.status != .inProgress(.responseErrorOccurred) else {
+                    chatView.showRetryView({
+                        guard let lastMessage = newRetrospect.chat.last else { return }
+
+                        // 재전송 로직이 들어가야 함
+                        print(lastMessage)
+                    })
+                    return
+                }
+                
                 let oldCount = previousMessageCount
                 let newCount = newRetrospect.chat.filter({ !$0.content.isEmpty }).count
                 previousMessageCount = newCount

--- a/RetsTalk/RetsTalk/Chat/View/ChatView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/ChatView.swift
@@ -112,9 +112,10 @@ final class ChatView: UIView {
     }
 
     func insertMessages(at indexPaths: [IndexPath]) {
-        chattingTableView.performBatchUpdates {
-            chattingTableView.insertRows(at: indexPaths, with: .bottom)
-        }
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        chattingTableView.insertRows(at: indexPaths, with: .none)
+        CATransaction.commit()
     }
 
     func updateRequestInProgressState(_ state: Bool) {

--- a/RetsTalk/RetsTalk/Chat/View/ChatView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/ChatView.swift
@@ -18,6 +18,7 @@ final class ChatView: UIView {
     private let messageInputView = MessageInputView()
     private var messageInputViewHeightConstraint: NSLayoutConstraint?
     private var chatViewBottomConstraint: NSLayoutConstraint?
+    private let retryView = RetryView()
     weak var delegate: ChatViewDelegate?
 
     override init(frame: CGRect) {
@@ -122,6 +123,33 @@ final class ChatView: UIView {
     func updateRequestInProgressState(_ state: Bool) {
         messageInputView.updateRequestInProgressState(state)
     }
+
+    // MARK: Retry button
+
+    func showRetryView(_ completion: @escaping () -> Void) {
+        addSubview(retryView)
+
+        retryView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+                retryView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metrics.retryButtonPadding),
+                retryView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Metrics.retryButtonPadding),
+                retryView.bottomAnchor
+                    .constraint(
+                        equalTo: messageInputView.topAnchor,
+                        constant: -Metrics.retryButtonBottomMargin
+                    ),
+            ])
+
+        retryView.addAction {
+            completion()
+            self.hideRetryView()
+        }
+    }
+
+    private func hideRetryView() {
+        retryView.removeFromSuperview()
+    }
 }
 
 // MARK: - MessageInputViewDelegate
@@ -149,5 +177,7 @@ private extension ChatView {
     enum Metrics {
         static let messageInputViewHeight = 54.0
         static let chatViewBottomFromBottom = -40.0
+        static let retryButtonPadding = 20.0
+        static let retryButtonBottomMargin = 10.0
     }
 }

--- a/RetsTalk/RetsTalk/Chat/View/ChatView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/ChatView.swift
@@ -92,13 +92,14 @@ final class ChatView: UIView {
         guard 0 < rows else { return }
         
         let indexPath = IndexPath(row: rows - 1, section: 0)
-        chattingTableView.scrollToRow(
-            at: indexPath,
-            at: .bottom,
-            animated: false
-        )
+        chattingTableView.scrollToRow(at: indexPath, at: .bottom, animated: false)
     }
-    
+
+    func scrollToTop() {
+        let indexPath = IndexPath(row: NSNotFound, section: 0)
+        chattingTableView.scrollToRow(at: indexPath, at: .top, animated: false)
+    }
+
     func setTableViewDelegate(_ delegate: UITableViewDelegate & UITableViewDataSource) {
         chattingTableView.delegate = delegate
         chattingTableView.dataSource = delegate

--- a/RetsTalk/RetsTalk/Chat/View/MessageInputView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/MessageInputView.swift
@@ -80,6 +80,7 @@ final class MessageInputView: UIView {
             self.delegate?.sendMessage(self, with: self.textInputView.text)
             self.textInputView.text = nil
             self.sendButton.isEnabled = false
+            updateHeight(to: currentTextViewHeight(textView: textInputView))
             self.updateRequestInProgressState(true)
         }), for: .touchUpInside)
     }
@@ -162,8 +163,11 @@ final class MessageInputView: UIView {
         sendButton.isEnabled = !isRequestInProgress && textInputView.text.isNotEmpty && isPlaceholderDeactivated
     }
 
-    private func updateSendButtonState(isEnabled: Bool) {
-        sendButton.isEnabled = isEnabled
+    private func currentTextViewHeight(textView: UITextView) -> Double {
+        let contentSize = textView.sizeThatFits(CGSize(width: textView.frame.width, height: .infinity))
+        let inputViewHeight = contentSize.height + 2 * Metrics.textViewVerticalMargin
+
+        return max(inputViewHeight, Metrics.backgroundHeight)
     }
 
     func updateRequestInProgressState(_ state: Bool) {
@@ -175,14 +179,13 @@ final class MessageInputView: UIView {
 
 extension MessageInputView: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
-        let contentSize = textView.sizeThatFits(CGSize(width: textView.frame.width, height: .infinity))
-        let inputViewHeight = contentSize.height + 2 * Metrics.textViewVerticalMargin
+        let inputViewHeight = currentTextViewHeight(textView: textView)
 
         textView.isScrollEnabled = inputViewHeight > Metrics.textViewMaxHeight
         if textView.isScrollEnabled {
             updateHeight(to: Metrics.textViewMaxHeight)
         } else {
-            updateHeight(to: max(Metrics.backgroundHeight, inputViewHeight))
+            updateHeight(to: inputViewHeight)
         }
         updateSendButtonState()
     }

--- a/RetsTalk/RetsTalk/Chat/View/RetryView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/RetryView.swift
@@ -81,7 +81,7 @@ final class RetryView: UIView {
     }
 }
 
-// MARK: - constants
+// MARK: - Constants
 
 private extension RetryView {
     enum Metrics {

--- a/RetsTalk/RetsTalk/Chat/View/RetryView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/RetryView.swift
@@ -81,10 +81,9 @@ final class RetryView: UIView {
     }
 }
 
-private extension RetryView {
-    
-    // MARK: constants
+// MARK: - constants
 
+private extension RetryView {
     enum Metrics {
         static let cornerRadius = 16.0
         static let backgroundBorderWidth = 0.5


### PR DESCRIPTION
##  📌 관련 이슈

- Closes #94 
- Closes #95 
- Closes #96 

## ✨ 세부 내용

### 스크린샷
|TextInput길이 초기화|재전송 버튼 띄우기|
|-|-|
|<img src="https://i.imgur.com/wjwMSHD.gif" width="350" />|<img src="https://i.imgur.com/Ll2vJJ5.gif" width="350" />|
- 여러 줄의 메시지를 전송한 뒤 InputView의 길이가 줄어들지 않는 문제를 수정하였습니다.
- 올바른 응답이 오지 않아 Retrospect의 state가 responseErrorOccurred인 경우 재전송 버튼(화면)을 띄우게 하는 기능을 추가하였습니다.
- ScrollToTop 메서드를 구현하여 Retrospect의 state가 finished인 경우 해당 함수를 호출하여 맨 위부터 볼 수 있도록 하였습니다.


## ✍️ 고민한 내용

chatView의 showRetryView(_ completion: ) 함수를 통해 retryView가 추가가 됩니다. 재전송 버튼의 액션이 retryView.addAction() 함수를 통해 closure로 추가할 수 있도록 설계되어 있어서 showRetryView의 completion handler로 부터 재전송 로직이 RetryView까지 전달이 되게 됩니다. (클로저 두 번 중첩됨, ChattingViewController -> ChatView -> RetryView)
이 방식으로 작동이 문제가 없을 지 의문이 들긴 합니다.
Delegate도 그렇고 중첩되거나 여러 번 전달되는 경우 유쾌하지 않은 기분이 듭니다 🤔

## ⌛ 소요 시간
5H