### PR TITLE
사용자 설정 화면 UI 구현

### DIFF
--- a/RetsTalk/RetsTalk/User/UserSettingView.swift
+++ b/RetsTalk/RetsTalk/User/UserSettingView.swift
@@ -1,0 +1,69 @@
+//
+//  UserSettingView.swift
+//  RetsTalk
+//
+//  Created by HanSeung on 11/24/24.
+//
+
+import SwiftUI
+
+struct UserSettingView: View {
+    @State private var isOn = true
+    @State private var selectedDate = Date()
+    
+    var body: some View {
+        List {
+            Section("사용자 정보") {
+                HStack {
+                    Text("폭식하는 부덕이")
+                    Spacer()
+                    Button(action: {}, label: {
+                        Image(systemName: "pencil")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)  // 비율 유지
+                            .foregroundColor(.blazingOrange)
+                            .frame(width: 18)
+                    })
+                }
+            }
+            
+            Section("클라우드") {
+                HStack {
+                    Text("클라우드 동기화")
+                    Spacer()
+                    Toggle(isOn: $isOn) {}
+                        .toggleStyle(SwitchToggleStyle(tint: .blazingOrange))
+                }
+                Text("example@apple.com")
+                    .foregroundStyle(.gray)
+            }
+            
+            Section("알림") {
+                HStack {
+                    Text("회고 작성 알림")
+                    Spacer()
+                    Toggle(isOn: $isOn) {}
+                        .toggleStyle(SwitchToggleStyle(tint: .blazingOrange))
+                }
+                
+                if isOn {
+                    DatePicker("시간", selection: $selectedDate, displayedComponents: .hourAndMinute)
+                        .tint(.blazingOrange)
+                }
+            }
+            
+            Section("앱 정보") {
+                HStack {
+                    Text("앱 버전")
+                    Spacer()
+                    Text("1.1")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    UserSettingView()
+}

--- a/RetsTalk/RetsTalk/User/UserSettingView.swift
+++ b/RetsTalk/RetsTalk/User/UserSettingView.swift
@@ -78,7 +78,7 @@ private extension UserSettingView {
         
         var body: some View {
             HStack {
-                Text("클라우드 동기화")
+                Text(Texts.cloudSettingViewTitle)
                 Spacer()
                 Toggle(isOn: $isCloudSyncOn) {}
                     .toggleStyle(SwitchToggleStyle(tint: .blazingOrange))
@@ -98,7 +98,7 @@ private extension UserSettingView {
         
         var body: some View {
             HStack {
-                Text("회고 작성 알림")
+                Text(Texts.notificationSettingViewToggleTitle)
                 Spacer()
                 Toggle(isOn: $isNotificationOn) {}
                     .toggleStyle(SwitchToggleStyle(tint: .blazingOrange))
@@ -108,7 +108,11 @@ private extension UserSettingView {
             }
             
             if isNotificationOn {
-                DatePicker("시간", selection: $selectedDate, displayedComponents: .hourAndMinute)
+                DatePicker(
+                    Texts.notificationSettingViewDatePickerTitle,
+                    selection: $selectedDate,
+                    displayedComponents: .hourAndMinute
+                )
                     .tint(.blazingOrange)
                     .onChange(of: selectedDate) { _ in
                         action()
@@ -118,13 +122,13 @@ private extension UserSettingView {
     }
     
     struct AppVersionView: View {
-        private var appVersion: String? =  Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        private var appVersion: String? =  Bundle.main.infoDictionary?[Texts.appVersionViewBundleKey] as? String
         
         var body: some View {
             HStack {
-                Text("앱 버전")
+                Text(Texts.appVersionViewTitle)
                 Spacer()
-                Text(appVersion ?? "1.0")
+                Text(appVersion ?? Texts.appVersionDefaultValue)
                     .foregroundStyle(.secondary)
             }
         }
@@ -145,8 +149,17 @@ private extension UserSettingView {
         static let secondSectionTitle = "클라우드"
         static let thirdSectionTitle = "알림"
         static let fourthSectionTitle = "앱 정보"
+        
+        static let cloudSettingViewTitle = "클라우드 동기화"
+        static let notificationSettingViewToggleTitle = "회고 작성 알림"
+        static let notificationSettingViewDatePickerTitle = "회고 작성 알림"
+        static let appVersionViewTitle = "앱 버전"
+        static let appVersionViewBundleKey = "CFBundleShortVersionString"
+        static let appVersionDefaultValue = "1.0"
     }
 }
+
+// MARK: - Preview
 
 #Preview {
     UserSettingView()

--- a/RetsTalk/RetsTalk/User/UserSettingView.swift
+++ b/RetsTalk/RetsTalk/User/UserSettingView.swift
@@ -19,28 +19,28 @@ struct UserSettingView: View {
     @State private var isCloudSyncOn = true
     @State private var isNotificationOn = false
     @State private var selectedDate = Date()
-    
-    @State private var cloudAddress: String = "example@apple.com"
-    @State private var nickname: String = "폭식하는 부덕이"
+    @State private var cloudAddress: String = "example@apple.com" // 모델 연결 전
+    @State private var nickname: String = "폭식하는 부덕이" // 모델 연결 전
     
     var body: some View {
         List {
             Section(Texts.firstSectionTitle) {
-                NicknameView(nickname: $nickname) {
+                NicknameSettingView(nickname: $nickname) {
+                    // Alert 구현 전
                     delegate?.didChangeNickname(self, nickname: nickname)
                 }
             }
             
             Section(Texts.secondSectionTitle) {
-                CloudView(isCloudSyncOn: $isCloudSyncOn, cloudAddress: $cloudAddress) {
+                CloudSettingView(isCloudSyncOn: $isCloudSyncOn, cloudAddress: $cloudAddress) {
                     delegate?.didToggleCloudSync(self, isOn: isCloudSyncOn)
                 }
             }
             
             Section(Texts.thirdSectionTitle) {
-                NotificationView(isNotificationOn: $isNotificationOn, selectedDate: $selectedDate, action: {
+                NotificationSettingView(isNotificationOn: $isNotificationOn, selectedDate: $selectedDate) {
                     delegate?.didToggleNotification(self, isOn: isNotificationOn, selectedDate: selectedDate)
-                })
+                }
             }
             
             Section(Texts.fourthSectionTitle) {
@@ -51,10 +51,10 @@ struct UserSettingView: View {
 }
 
 private extension UserSettingView {
-    struct NicknameView: View {
+    struct NicknameSettingView: View {
         @Binding var nickname: String
         var action: () -> Void
-
+        
         var body: some View {
             HStack {
                 Text(nickname)
@@ -63,7 +63,7 @@ private extension UserSettingView {
                        label: {
                     Image(systemName: Texts.editButtonImageName)
                         .resizable()
-                        .aspectRatio(contentMode: .fit)  // 비율 유지
+                        .aspectRatio(contentMode: .fit)
                         .foregroundColor(.blazingOrange)
                         .frame(width: Metrics.editButtonSize)
                 })
@@ -71,11 +71,11 @@ private extension UserSettingView {
         }
     }
     
-    struct CloudView: View {
+    struct CloudSettingView: View {
         @Binding var isCloudSyncOn: Bool
         @Binding var cloudAddress: String
         var action: () -> Void
-
+        
         var body: some View {
             HStack {
                 Text("클라우드 동기화")
@@ -91,12 +91,11 @@ private extension UserSettingView {
         }
     }
     
-    struct NotificationView: View {
+    struct NotificationSettingView: View {
         @Binding var isNotificationOn: Bool
         @Binding var selectedDate: Date
         var action: () -> Void
-
-
+        
         var body: some View {
             HStack {
                 Text("회고 작성 알림")


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #103 

## ✨ 세부 내용

| swiftUI 뷰 구현 |
|---|
|<img width="250" alt="image" src="https://github.com/user-attachments/assets/c2c8d59b-c46d-4e23-a5c4-9bb91a2cdb14">|
## ✍️ 고민한 내용
UIKit의 테이블뷰를 이용할 예정이었으나, 셀마다 컴포넌트(액세서리뷰)가 달라 일괄적으로 적용할 수 없고 커스텀셀로 전부 만들기에 소모적이라고 판단하였음.
UIKit로도 서브뷰를 전부 구성하는 것 대신 swiftUI를 활용해 구현해보고자 함.


<!-- 해당 PR중 고민한 내용이 있으면 적어주세요. -->

## ⌛ 소요 시간
2시간