### PR TITLE
네트워크 레이어 행위자(actor) 격리(#111)

### DIFF
--- a/RetsTalk/RetsTalk/Chat/Model/AssistantMessageProvider.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/AssistantMessageProvider.swift
@@ -5,6 +5,6 @@
 //  Created on 11/19/24.
 //
 
-protocol AssistantMessageProvidable {
+protocol AssistantMessageProvidable: Actor {
     func requestAssistantMessage(for chat: [Message]) async throws -> Message
 }

--- a/RetsTalk/RetsTalk/Network/CLOVAStudio/CLOVAStudioManager.swift
+++ b/RetsTalk/RetsTalk/Network/CLOVAStudio/CLOVAStudioManager.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class CLOVAStudioManager: NetworkRequestable {
+actor CLOVAStudioManager: NetworkRequestable {
     let urlSession: URLSession
     
     init(urlSession: URLSession) {

--- a/RetsTalk/RetsTalk/Network/NetworkRequestable.swift
+++ b/RetsTalk/RetsTalk/Network/NetworkRequestable.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol NetworkRequestable {
+protocol NetworkRequestable: Actor {
     var urlSession: URLSession { get }
     
     func request(with urlRequestComposer: any URLRequestComposable) async throws -> Data

--- a/RetsTalk/RetsTalkTests/Mock/MockAssistantMessageProvider.swift
+++ b/RetsTalk/RetsTalkTests/Mock/MockAssistantMessageProvider.swift
@@ -7,8 +7,8 @@
 
 import XCTest
 
-struct MockAssistantMessageProvider: AssistantMessageProvidable {
-    nonisolated(unsafe) static var requestAssistantMessageHandler: (([Message]) throws -> Message)?
+actor MockAssistantMessageProvider: AssistantMessageProvidable {
+    static var requestAssistantMessageHandler: (([Message]) throws -> Message)?
 
     func requestAssistantMessage(for chat: [Message]) async throws -> Message {
         guard let handler = MockAssistantMessageProvider.requestAssistantMessageHandler


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- close: #111

## ✨ 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

네트워크 레이어를 행위자(actor)를 통해 격리합니다.

## ✍️ 고민한 내용

<!-- 해당 PR중 고민한 내용이 있으면 적어주세요. -->

### 행위자로 격리를 함으로써

- 네트워크 레이어에서 수행하는 작업들이 메인 스레드에서 수행되지 않음을 보장합니다.
- 네트워크 레이어의 데이터 및 로직이 동시성의 상황에서 안전하게 처리됨을 보장합니다.

## ⌛ 소요 시간

5m
