### PR TITLE
로컬 저장소 레이어 행위자(actor) 격리(#113)

### DIFF
--- a/RetsTalk/PersistTests/PersistTests.swift
+++ b/RetsTalk/PersistTests/PersistTests.swift
@@ -50,11 +50,8 @@ final class PersistTests: XCTestCase {
         try await addMultipleEntities(ofContents: testableContents)
         let targetContent = try XCTUnwrap(testableContents.randomElement())
         
-        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-            NSPredicate(format: "content = %@", argumentArray: [targetContent]),
-            NSPredicate(format: "integer = %@", argumentArray: [0]),
-        ])
-        let request = PersistfetchRequest<TestEntity>(predicate: predicate, fetchLimit: 5)
+        let predicate = CustomPredicate(format: "content = %@ AND integer = %@", argumentArray: [targetContent, 0])
+        let request = PersistFetchRequest<TestEntity>(predicate: predicate, fetchLimit: 5)
         let fetchedEntities = try await persistentManager.fetch(by: request)
         
         XCTAssertEqual(fetchedEntities.count, 1)
@@ -81,7 +78,7 @@ final class PersistTests: XCTestCase {
         
         try await persistentManager.delete(contentsOf: [targetEntity])
         
-        let allEntities = try await persistentManager.fetch(by: PersistfetchRequest<TestEntity>(fetchLimit: 5))
+        let allEntities = try await persistentManager.fetch(by: PersistFetchRequest<TestEntity>(fetchLimit: 5))
         XCTAssertEqual(allEntities.count, testableContents.count - 1)
         XCTAssertFalse(allEntities.contains(where: { $0.content == targetContent }))
     }

--- a/RetsTalk/RetsTalk.xcodeproj/project.pbxproj
+++ b/RetsTalk/RetsTalk.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 				Chat/Model/RetrospectChatManager.swift,
 				Chat/Model/RetrospectChatManagerListener.swift,
 				Persistent/EntityRepresentable.swift,
+				Persistent/Implementation/PersistFetchRequest.swift,
 				Persistent/Persistable.swift,
 				Persistent/PersistFetchRequestable.swift,
 				Retrospect/Model/Retrospect.swift,
@@ -93,6 +94,7 @@
 			membershipExceptions = (
 				Persistent/EntityRepresentable.swift,
 				Persistent/Implementation/CoreDataManager.swift,
+				Persistent/Implementation/PersistFetchRequest.swift,
 				Persistent/Persistable.swift,
 				Persistent/PersistFetchRequestable.swift,
 				"Utility/Extensions/Collection+Extension.swift",

--- a/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
@@ -63,10 +63,10 @@ final class RetrospectChatManager: RetrospectChatManageable, @unchecked Sendable
     
     // MARK: Supporting methods
     
-    private func recentMessageFetchRequest(offset: Int, amount: Int) -> PersistfetchRequest<Message> {
-        let matchingRetorspect = NSPredicate(format: "retrospectID = %@", argumentArray: [retrospect.id])
-        let recentDateSorting = NSSortDescriptor(key: "createdAt", ascending: false)
-        let request = PersistfetchRequest<Message>(
+    private func recentMessageFetchRequest(offset: Int, amount: Int) -> PersistFetchRequest<Message> {
+        let matchingRetorspect = CustomPredicate(format: "retrospectID = %@", argumentArray: [retrospect.id])
+        let recentDateSorting = CustomSortDescriptor(key: "createdAt", ascending: false)
+        let request = PersistFetchRequest<Message>(
             predicate: matchingRetorspect,
             sortDescriptors: [recentDateSorting],
             fetchLimit: amount,

--- a/RetsTalk/RetsTalk/Persistent/Implementation/CoreDataManager.swift
+++ b/RetsTalk/RetsTalk/Persistent/Implementation/CoreDataManager.swift
@@ -116,8 +116,8 @@ final class CoreDataManager: Persistable, @unchecked Sendable {
     ) -> NSFetchRequest<NSFetchRequestResult> where Entity: EntityRepresentable {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: Entity.entityName)
         fetchRequest.resultType = .dictionaryResultType
-        fetchRequest.predicate = request.predicate
-        fetchRequest.sortDescriptors = request.sortDescriptors
+        fetchRequest.predicate = request.predicate?.nsPredicate
+        fetchRequest.sortDescriptors = request.sortDescriptors.map { $0.nsSortDescriptor }
         fetchRequest.fetchLimit = request.fetchLimit
         fetchRequest.fetchOffset = request.fetchOffset
         return fetchRequest

--- a/RetsTalk/RetsTalk/Persistent/Implementation/CoreDataManager.swift
+++ b/RetsTalk/RetsTalk/Persistent/Implementation/CoreDataManager.swift
@@ -5,9 +5,9 @@
 //  Created by MoonGoon on 11/13/24.
 //
 
-import CoreData
+@preconcurrency import CoreData
 
-final class CoreDataManager: Persistable, @unchecked Sendable {
+actor CoreDataManager: Persistable {
     private let persistentContainer: NSPersistentContainer
     private var lastHistoryDate: Date
     
@@ -32,7 +32,7 @@ final class CoreDataManager: Persistable, @unchecked Sendable {
         }
     }
     
-    private func setUpPersistentContainer(inMemory: Bool) throws {
+    private nonisolated func setUpPersistentContainer(inMemory: Bool) throws {
         guard let description = persistentContainer.persistentStoreDescriptions.first
         else { throw Error.storeSetUpFailed }
         
@@ -51,7 +51,7 @@ final class CoreDataManager: Persistable, @unchecked Sendable {
         guard entities.isNotEmpty else { return [] }
         
         let taskContext = newTaskContext()
-        try await taskContext.perform { [weak self] in
+        try await taskContext.sendablePerform { [weak self] in
             guard let batchInsertRequest = self?.batchInsertRequest(for: entities),
                   let batchInsertResult = try? taskContext.execute(batchInsertRequest) as? NSBatchInsertResult,
                   let success = batchInsertResult.result as? Bool, success
@@ -65,14 +65,14 @@ final class CoreDataManager: Persistable, @unchecked Sendable {
         by request: any PersistFetchRequestable<Entity>
     ) async throws -> [Entity] where Entity: EntityRepresentable {
         let taskContext = newTaskContext()
-        let dictionaryList = try await taskContext.perform { [weak self] in
+        let fetchedEntities = try await taskContext.sendablePerform { [weak self] in
             guard let fetchRequest = self?.fetchRequest(from: request),
                   let dictionaryList = try? taskContext.fetch(fetchRequest) as? [NSDictionary]
             else { throw Error.fetchingFailed }
             
-            return dictionaryList
+            return dictionaryList.map { Entity(dictionary: $0 as? [String: Any] ?? [:]) }
         }
-        return dictionaryList.map { Entity(dictionary: $0 as? [String: Any] ?? [:]) }
+        return fetchedEntities
     }
     
     func update<Entity>(
@@ -80,7 +80,7 @@ final class CoreDataManager: Persistable, @unchecked Sendable {
         to updatingEntity: Entity
     ) async throws -> Entity where Entity: EntityRepresentable {
         let taskContext = newTaskContext()
-        try await taskContext.perform { [weak self] in
+        try await taskContext.sendablePerform { [weak self] in
             guard let batchUpdateRequest = self?.batchUpdateRequest(from: sourceEntity, to: updatingEntity),
                   let batchUpdateResult = try? taskContext.execute(batchUpdateRequest) as? NSBatchUpdateResult,
                   let success = batchUpdateResult.result as? Bool, success
@@ -93,7 +93,7 @@ final class CoreDataManager: Persistable, @unchecked Sendable {
     func delete<Entity>(contentsOf entities: [Entity]) async throws where Entity: EntityRepresentable {
         let taskContext = newTaskContext()
         for entity in entities {
-            try await taskContext.perform { [weak self] in
+            try await taskContext.sendablePerform { [weak self] in
                 guard let batchDeleteRequest = self?.batchDeleteRequest(for: entity),
                       let batchDeleteResult = try taskContext.execute(batchDeleteRequest) as? NSBatchDeleteResult,
                       let success = batchDeleteResult.result as? Bool, success
@@ -111,7 +111,7 @@ final class CoreDataManager: Persistable, @unchecked Sendable {
         return taskContext
     }
     
-    private func fetchRequest<Entity>(
+    private nonisolated func fetchRequest<Entity>(
         from request: any PersistFetchRequestable<Entity>
     ) -> NSFetchRequest<NSFetchRequestResult> where Entity: EntityRepresentable {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: Entity.entityName)
@@ -123,7 +123,9 @@ final class CoreDataManager: Persistable, @unchecked Sendable {
         return fetchRequest
     }
     
-    private func entityPredicate<Entity>(_ entity: Entity) -> NSPredicate where Entity: EntityRepresentable {
+    private nonisolated func entityPredicate<Entity>(
+        _ entity: Entity
+    ) -> NSPredicate where Entity: EntityRepresentable {
         let predicates = entity.mappingDictionary.map { (key, value) in
             NSPredicate(format: "\(key) == %@", argumentArray: [value])
         }
@@ -132,7 +134,7 @@ final class CoreDataManager: Persistable, @unchecked Sendable {
     
     // MARK: Batch request
     
-    private func batchInsertRequest<Entity>(
+    private nonisolated func batchInsertRequest<Entity>(
         for entities: [Entity]
     ) -> NSBatchInsertRequest where Entity: EntityRepresentable {
         var index = 0
@@ -146,7 +148,7 @@ final class CoreDataManager: Persistable, @unchecked Sendable {
         return batchInsertRequest
     }
     
-    private func batchUpdateRequest<Entity>(
+    private nonisolated func batchUpdateRequest<Entity>(
         from sourceEntity: Entity,
         to updatingEntity: Entity
     ) -> NSBatchUpdateRequest where Entity: EntityRepresentable {
@@ -156,7 +158,7 @@ final class CoreDataManager: Persistable, @unchecked Sendable {
         return batchUpdateRequest
     }
     
-    private func batchDeleteRequest<Entity>(
+    private nonisolated func batchDeleteRequest<Entity>(
         for entity: Entity
     ) -> NSBatchDeleteRequest where Entity: EntityRepresentable {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: Entity.entityName)
@@ -169,7 +171,7 @@ final class CoreDataManager: Persistable, @unchecked Sendable {
     private func mergePersistentHistoryChanges() async throws {
         let viewContext = persistentContainer.viewContext
         let history = try await fetchPersistentHistoryTransactionsAndChanges()
-        await viewContext.perform {
+        await viewContext.sendablePerform {
             for transaction in history {
                 viewContext.mergeChanges(fromContextDidSave: transaction.objectIDNotification())
             }
@@ -180,7 +182,7 @@ final class CoreDataManager: Persistable, @unchecked Sendable {
     private func fetchPersistentHistoryTransactionsAndChanges() async throws -> [NSPersistentHistoryTransaction] {
         let taskContext = newTaskContext()
         let changeRequest = NSPersistentHistoryChangeRequest.fetchHistory(after: lastHistoryDate)
-        let historyChanges = try await taskContext.perform {
+        let historyChanges = try await taskContext.sendablePerform {
             let historyResult = try taskContext.execute(changeRequest) as? NSPersistentHistoryResult
             guard let history = historyResult?.result as? [NSPersistentHistoryTransaction]
             else { throw Error.persistentHistoryChangeError }
@@ -192,9 +194,9 @@ final class CoreDataManager: Persistable, @unchecked Sendable {
     
     // MARK: Old history deletion
     
-    private func deleteOldPersistentHistory() {
+    private nonisolated func deleteOldPersistentHistory() {
         Task {
-            let taskContext = newTaskContext()
+            let taskContext = await newTaskContext()
             let deleteRequest = NSPersistentHistoryChangeRequest.deleteHistory(before: Date().aMonthAgo())
             _ = try await taskContext.perform {
                 try taskContext.execute(deleteRequest)
@@ -232,6 +234,17 @@ extension CoreDataManager {
                 "데이터를 삭제하는데 실패했습니다."
             }
         }
+    }
+}
+
+// MARK: - Extends NSManagedObjectContext for @Sendable perform
+
+fileprivate extension NSManagedObjectContext {
+    func sendablePerform<T>(
+        schedule: NSManagedObjectContext.ScheduledTaskType = .immediate,
+        _ block: @Sendable @escaping () throws -> T
+    ) async rethrows -> T {
+        try await perform(block)
     }
 }
 

--- a/RetsTalk/RetsTalk/Persistent/Implementation/PersistFetchRequest.swift
+++ b/RetsTalk/RetsTalk/Persistent/Implementation/PersistFetchRequest.swift
@@ -1,0 +1,27 @@
+//
+//  PersistFetchRequest.swift
+//  RetsTalk
+//
+//  Created by Byeongjo Koo on 11/25/24.
+//
+
+import Foundation
+
+struct PersistFetchRequest<Entity: EntityRepresentable>: PersistFetchRequestable {
+    var predicate: CustomPredicate?
+    var sortDescriptors: [CustomSortDescriptor]
+    var fetchLimit: Int
+    var fetchOffset: Int
+    
+    init(
+        predicate: CustomPredicate? = nil,
+        sortDescriptors: [CustomSortDescriptor] = [],
+        fetchLimit: Int,
+        fetchOffset: Int = 0
+    ) {
+        self.predicate = predicate
+        self.sortDescriptors = sortDescriptors
+        self.fetchLimit = fetchLimit
+        self.fetchOffset = fetchOffset
+    }
+}

--- a/RetsTalk/RetsTalk/Persistent/PersistFetchRequestable.swift
+++ b/RetsTalk/RetsTalk/Persistent/PersistFetchRequestable.swift
@@ -7,32 +7,31 @@
 
 import Foundation
 
-protocol PersistFetchRequestable<Entity> {
+protocol PersistFetchRequestable<Entity>: Sendable {
     associatedtype Entity: EntityRepresentable
     
-    var predicate: NSPredicate? { get }
-    var sortDescriptors: [NSSortDescriptor] { get }
+    var predicate: CustomPredicate? { get }
+    var sortDescriptors: [CustomSortDescriptor] { get }
     /// 검색을 통해 최대로 가져올 수 있는 수.
     var fetchLimit: Int { get }
     /// 검색 후 데이터를 가져오는 시작점.
     var fetchOffset: Int { get }
 }
 
-struct PersistfetchRequest<Entity: EntityRepresentable>: PersistFetchRequestable {
-    var predicate: NSPredicate?
-    var sortDescriptors: [NSSortDescriptor]
-    var fetchLimit: Int
-    var fetchOffset: Int
+struct CustomPredicate: @unchecked Sendable {
+    let format: String
+    let argumentArray: [Any]
     
-    init(
-        predicate: NSPredicate? = nil,
-        sortDescriptors: [NSSortDescriptor] = [],
-        fetchLimit: Int,
-        fetchOffset: Int = 0
-    ) {
-        self.predicate = predicate
-        self.sortDescriptors = sortDescriptors
-        self.fetchLimit = fetchLimit
-        self.fetchOffset = fetchOffset
+    var nsPredicate: NSPredicate {
+        NSPredicate(format: format, argumentArray: argumentArray)
+    }
+}
+
+struct CustomSortDescriptor {
+    let key: String
+    let ascending: Bool
+    
+    var nsSortDescriptor: NSSortDescriptor {
+        NSSortDescriptor(key: key, ascending: ascending)
     }
 }

--- a/RetsTalk/RetsTalk/Persistent/Persistable.swift
+++ b/RetsTalk/RetsTalk/Persistent/Persistable.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol Persistable {
+protocol Persistable: Actor {
     /// 로컬 저장소에 엔티티 데이터를 추가합니다.
     /// - Parameter entities: 추가할 엔티티 배열.
     /// - Returns: 추가된 데이터.

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -74,14 +74,11 @@ final class RetrospectManager: RetrospectManageable {
 // MARK: - ChatManager Create FetchRequest
 
 extension RetrospectManager {
-    private func pinnedRetrospectFetchRequest() -> PersistfetchRequest<Retrospect> {
-        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-            NSPredicate(format: "userID = %@", argumentArray: [userID]),
-            NSPredicate(format: "isPinned = %@", argumentArray: [true]),
-        ])
-        let sortDescriptors = NSSortDescriptor(key: "createdAt", ascending: false)
+    private func pinnedRetrospectFetchRequest() -> PersistFetchRequest<Retrospect> {
+        let predicate = CustomPredicate(format: "userID = %@ AND isPinned = %@", argumentArray: [userID, true])
+        let sortDescriptors = CustomSortDescriptor(key: "createdAt", ascending: false)
         
-        let request = PersistfetchRequest<Retrospect>(
+        let request = PersistFetchRequest<Retrospect>(
             predicate: predicate,
             sortDescriptors: [sortDescriptors],
             fetchLimit: Metrics.isPinnedFetchAmount
@@ -90,14 +87,14 @@ extension RetrospectManager {
         return request
     }
     
-    private func inProgressRetrospectFetchRequest() -> PersistfetchRequest<Retrospect> {
-        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-            NSPredicate(format: "userID = %@", argumentArray: [userID]),
-            NSPredicate(format: "status != %@", argumentArray: [Texts.finishedStatus]),
-        ])
-        let sortDescriptors = NSSortDescriptor(key: "createdAt", ascending: false)
+    private func inProgressRetrospectFetchRequest() -> PersistFetchRequest<Retrospect> {
+        let predicate = CustomPredicate(
+            format: "userID = %@ AND status != %@",
+            argumentArray: [userID, Texts.finishedStatus]
+        )
+        let sortDescriptors = CustomSortDescriptor(key: "createdAt", ascending: false)
         
-        let request = PersistfetchRequest<Retrospect>(
+        let request = PersistFetchRequest<Retrospect>(
             predicate: predicate,
             sortDescriptors: [sortDescriptors],
             fetchLimit: Metrics.isProgressFetchAmount
@@ -106,15 +103,14 @@ extension RetrospectManager {
         return request
     }
     
-    private func recentFinishedRetrospectFetchRequest(offset: Int, amount: Int) -> PersistfetchRequest<Retrospect> {
-        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-            NSPredicate(format: "userID = %@", argumentArray: [userID]),
-            NSPredicate(format: "status = %@", argumentArray: [Texts.finishedStatus]),
-            NSPredicate(format: "isPinned = %@", argumentArray: [false]),
-        ])
-        let sortDescriptors = NSSortDescriptor(key: "createdAt", ascending: false)
+    private func recentFinishedRetrospectFetchRequest(offset: Int, amount: Int) -> PersistFetchRequest<Retrospect> {
+        let predicate = CustomPredicate(
+            format: "userID = %@ AND status = %@ AND isPinned = %@",
+            argumentArray: [userID, Texts.finishedStatus, false]
+        )
+        let sortDescriptors = CustomSortDescriptor(key: "createdAt", ascending: false)
         
-        let request = PersistfetchRequest<Retrospect>(
+        let request = PersistFetchRequest<Retrospect>(
             predicate: predicate,
             sortDescriptors: [sortDescriptors],
             fetchLimit: amount,
@@ -124,7 +120,6 @@ extension RetrospectManager {
         return request
     }
 }
-
 
 // MARK: - MessageManagerListener conformance
 

--- a/RetsTalk/RetsTalkTests/Mock/MockMessageStore.swift
+++ b/RetsTalk/RetsTalkTests/Mock/MockMessageStore.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class MockMessageStore: Persistable {
+actor MockMessageStore: Persistable {
     var messages: [Message]
     
     init(messages: [Message]) {

--- a/RetsTalk/RetsTalkTests/Mock/MockRetrospectStore.swift
+++ b/RetsTalk/RetsTalkTests/Mock/MockRetrospectStore.swift
@@ -5,7 +5,7 @@
 //  Created by KimMinSeok on 11/24/24.
 //
 
-final class MockRetrospectStore: Persistable {
+actor MockRetrospectStore: Persistable {
     var retrospects: [Retrospect] = []
     
     init(retrospects: [Retrospect]) {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- close: #113 

## ✨ 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

로컬 저장소 레이어를 행위자(actor)를 통해 격리합니다.

## ✍️ 고민한 내용

<!-- 해당 PR중 고민한 내용이 있으면 적어주세요. -->

### 행위자로 격리를 함으로써
- 로컬 저장소 레이어에서 수행하는 작업들이 메인 스레드에서 수행되지 않음을 보장합니다.
- 로컬 저장소 레이어의 데이터 및 로직이 동시성의 상황에서 안전하게 처리됨을 보장합니다.

## ⌛ 소요 시간

40m