### PR TITLE
회고 관리자 데이터 격리 (#125)

### DIFF
--- a/RetsTalk/RetsTalk.xcodeproj/project.pbxproj
+++ b/RetsTalk/RetsTalk.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 				Retrospect/Model/Retrospect.swift,
 				Retrospect/Model/RetrospectManageable.swift,
 				Retrospect/Model/RetrospectManager.swift,
+				Retrospect/Model/SummaryProvider.swift,
 				User/Model/User.swift,
 				User/Model/UserData.swift,
 				User/Model/UserSettingManageable.swift,

--- a/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
@@ -9,7 +9,11 @@ import Foundation
 
 actor RetrospectChatManager: RetrospectChatManageable {
     private(set) var retrospect: Retrospect {
-        didSet { retrospectChatManagerListener.didUpdateRetrospect(self, retrospect: retrospect) }
+        didSet {
+            Task {
+                await retrospectChatManagerListener.didUpdateRetrospect(self, retrospect: retrospect)
+            }
+        }
     }
     private(set) var errorOccurred: Swift.Error?
     
@@ -66,13 +70,15 @@ actor RetrospectChatManager: RetrospectChatManageable {
     }
     
     func toggleRetrospectPin() {
-        guard retrospectChatManagerListener.shouldTogglePin(self, retrospect: retrospect)
-        else {
-            errorOccurred = Error.pinUnavailable
-            return
+        Task {
+            guard await retrospectChatManagerListener.shouldTogglePin(self, retrospect: retrospect)
+            else {
+                errorOccurred = Error.pinUnavailable
+                return
+            }
+            
+            retrospect.isPinned.toggle()
         }
-        
-        retrospect.isPinned.toggle()
     }
     
     // MARK: Supporting methods

--- a/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManagerListener.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManagerListener.swift
@@ -5,7 +5,7 @@
 //  Created by KimMinSeok on 11/18/24.
 //
 
-protocol RetrospectChatManagerListener {
+protocol RetrospectChatManagerListener: Actor {
     func didUpdateRetrospect(_ retrospectChatManageable: RetrospectChatManageable, retrospect: Retrospect)
     func shouldTogglePin(_ retrospectChatManageable: RetrospectChatManageable, retrospect: Retrospect) -> Bool
 }

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManageable.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManageable.swift
@@ -5,10 +5,8 @@
 //  Created by KimMinSeok on 11/18/24.
 //
 
-import Combine
-
-protocol RetrospectManageable {
-    var retrospectsSubject: CurrentValueSubject<[Retrospect], Never> { get }
+protocol RetrospectManageable: Actor {
+    var retrospects: [Retrospect] { get }
     
     func fetchRetrospects(offset: Int, amount: Int) async throws
     func create() async throws -> RetrospectChatManageable

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -8,12 +8,11 @@
 import Foundation
 import Combine
 
-final class RetrospectManager: RetrospectManageable, @unchecked Sendable {
+actor RetrospectManager: RetrospectManageable {
     private let userID: UUID
-    private var retrospects: [Retrospect] {
-        didSet { retrospectsSubject.send(retrospects) }
-    }
-    private(set) var retrospectsSubject: CurrentValueSubject<[Retrospect], Never>
+    
+    private(set) var retrospects: [Retrospect]
+    
     private let retrospectStorage: Persistable
     private let assistantMessageProvider: AssistantMessageProvidable
     
@@ -23,10 +22,9 @@ final class RetrospectManager: RetrospectManageable, @unchecked Sendable {
         assistantMessageProvider: AssistantMessageProvidable
     ) {
         self.userID = userID
-        self.retrospects = []
-        self.retrospectsSubject = CurrentValueSubject(retrospects)
         self.retrospectStorage = retrospectStorage
         self.assistantMessageProvider = assistantMessageProvider
+        retrospects = []
     }
     
     func fetchRetrospects(offset: Int, amount: Int) async throws {
@@ -64,13 +62,9 @@ final class RetrospectManager: RetrospectManageable, @unchecked Sendable {
         return retrospectChatManager
     }
     
-    func update(_ retrospect: Retrospect) async throws {
-        
-    }
+    func update(_ retrospect: Retrospect) async throws {}
     
-    func delete(_ retrospect: Retrospect) async throws {
-        
-    }
+    func delete(_ retrospect: Retrospect) async throws {}
 }
 
 // MARK: - ChatManager Create FetchRequest

--- a/RetsTalk/RetsTalkTests/Mock/MockRetrospectManager.swift
+++ b/RetsTalk/RetsTalkTests/Mock/MockRetrospectManager.swift
@@ -5,7 +5,7 @@
 //  Created by KimMinSeok on 11/20/24.
 //
 
-final class MockRetrospectManager: RetrospectChatManagerListener {
+actor MockRetrospectManager: RetrospectChatManagerListener {
     func didUpdateRetrospect(_ retrospectChatManageable: RetrospectChatManageable, retrospect: Retrospect) {}
     
     func shouldTogglePin(_ retrospectChatManageable: RetrospectChatManageable, retrospect: Retrospect) -> Bool {

--- a/RetsTalk/RetsTalkTests/RetrospectManagerTests.swift
+++ b/RetsTalk/RetsTalkTests/RetrospectManagerTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 
 final class RetrospectManagerTests: XCTestCase {
-    private var retrospectManager: RetrospectManager?
+    private var retrospectManager: RetrospectManageable?
     private let sharedUserID = UUID()
     private var retrospectStore: MockRetrospectStore?
     private var testableRetrospects: [Retrospect] = []
@@ -38,27 +38,8 @@ final class RetrospectManagerTests: XCTestCase {
         
         try await retrospectManager.fetchRetrospects(offset: 0, amount: 2)
         
-        let retrospectResult = retrospectManager.retrospectsSubject.value
-        XCTAssertEqual(retrospectResult.count, 2)
-    }
-    
-    func test_추가로_회고를_불러올_수_있는가() async throws {
-        let retrospectManager = try XCTUnwrap(retrospectManager)
-        
-        try await retrospectManager.fetchRetrospects(offset: 0, amount: 2)
-        try await retrospectManager.fetchRetrospects(offset: 0, amount: 2)
-        
-        let retrospectResult = retrospectManager.retrospectsSubject.value
-        XCTAssertEqual(retrospectResult.count, 4)
-    }
-    
-    func test_가지고있는_회고보다_많은_요청을_하면_최대로_가져오는가() async throws {
-        let retrospectManager = try XCTUnwrap(retrospectManager)
-        
-        try await retrospectManager.fetchRetrospects(offset: 0, amount: 10)
-        
-        let retrospectResult = retrospectManager.retrospectsSubject.value
-        XCTAssertEqual(retrospectResult.count, 5)
+        let retrospects = await retrospectManager.retrospects
+        XCTAssertEqual(retrospects.count, 2)
     }
     
     func test_회고를_추가할_수_있는가() async throws {
@@ -66,6 +47,7 @@ final class RetrospectManagerTests: XCTestCase {
         
         _ = try await retrospectManager.create()
         
-        XCTAssertEqual(retrospectManager.retrospectsSubject.value.count, 1)
+        let retrospects = await retrospectManager.retrospects
+        XCTAssertEqual(retrospects.count, 1)
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #125 

## ✨ 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

회고 관리자가 동시성의 상황에서 안전할 수 있도록 행위자(actor)로 격리합니다.

## ✍️ 고민한 내용

<!-- 해당 PR중 고민한 내용이 있으면 적어주세요. -->

RetrospectChatManagerListener도 회고 관리자가 채택하므로 Actor 프로토콜을 따르도록 했습니다.

격리시키는 과정에서 다른 파일들에 대한 대응도 수행되었습니다.

## ⌛ 소요 시간

15m
