### PR TITLE
뷰 컨트롤러 계층화

### DIFF
--- a/RetsTalk/RetsTalk/Utility/View/AlertPresentable.swift
+++ b/RetsTalk/RetsTalk/Utility/View/AlertPresentable.swift
@@ -1,0 +1,35 @@
+//
+//  AlertPresentable.swift
+//  RetsTalk
+//
+//  Created by HanSeung on 11/27/24.
+//
+
+import UIKit
+
+@MainActor
+protocol AlertPresentable {
+    associatedtype Situation: AlertSituation
+    
+    /// 알림을 화면에 표시합니다.
+    /// 알림의 제목과 메시지는 Situation 타입에서 제공된 title과 message를 사용하며, 사용자가 선택할 수 있는 액션들은 actions 배열에 추가됩니다.
+    /// - Parameters:
+    ///   - situation: 알림의 제목과 메시지를 제공하는 객체입니다. Situation 타입은 AlertSituation 프로토콜을 준수해야 합니다.
+    ///   - actions: 알림에 추가할 액션들입니다. 각 액션은 UIAlertAction 객체로 제공됩니다.
+    func presentAlert(for situation: Situation, actions: [UIAlertAction])
+}
+
+extension AlertPresentable where Self: BaseViewController {
+    func presentAlert(for situation: Situation, actions: [UIAlertAction]) {
+        let alert = UIAlertController(title: situation.title, message: situation.message, preferredStyle: .alert)
+        actions.forEach { alert.addAction($0) }
+        present(alert, animated: true)
+    }
+}
+
+protocol AlertSituation {
+    /// 알림의 제목을 반환하는 문자열입니다.
+    var title: String { get }
+    /// 알림의 내용을 담고 있는 문자열입니다.
+    var message: String { get }
+}

--- a/RetsTalk/RetsTalk/Utility/View/BaseKeyBoardViewController.swift
+++ b/RetsTalk/RetsTalk/Utility/View/BaseKeyBoardViewController.swift
@@ -1,0 +1,56 @@
+//
+//  BaseKeyBoardViewController.swift
+//  RetsTalk
+//
+//  Created by HanSeung on 11/27/24.
+//
+
+import UIKit
+
+class BaseKeyBoardViewController: BaseViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        addKeyboardObservers()
+        addTapGestureOfDismissingKeyboard()
+    }
+    
+    // MARK: TapGesture of KeyboardDismissing
+    
+    private func addTapGestureOfDismissingKeyboard() {
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        view.addGestureRecognizer(tapGestureRecognizer)
+    }
+    
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
+    }
+    
+    // MARK: KeyboardObserving
+    
+    private func addKeyboardObservers() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShowAndHide(_:)),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShowAndHide(_:)),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+    }
+    
+    @objc private func keyboardWillShowAndHide(_ notification: Notification) {
+        if let userInfo = notification.userInfo,
+           let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+            keyboardWillUpdateConstraint(keyboardHeight: keyboardFrame.height)
+        }
+    }
+    
+    /// 이 함수는 키보드 호출 시 높이를 전달받아 레이아웃을 조정합니다.
+    /// - Parameter keyboardHeight: 키보드 높이
+    func keyboardWillUpdateConstraint(keyboardHeight: CGFloat) { }
+}

--- a/RetsTalk/RetsTalk/Utility/View/BaseViewController.swift
+++ b/RetsTalk/RetsTalk/Utility/View/BaseViewController.swift
@@ -9,21 +9,22 @@ import UIKit
 
 class BaseViewController: UIViewController, UINavigationControllerDelegate {
     /// 현재 네비게이션 컨트롤러 상태에 따라 뷰 컨트롤러를 pop 또는 dismiss합니다.
-    func onClickBack() {
-            if let navigationController = self.navigationController,
-                navigationController.viewControllers.count > 1 {
-                navigationController.popViewController(animated: true)
-            } else {
-                self.dismiss(animated: true, completion: nil)
-            }
+    func didTapNavigationBackButton() {
+        if let navigationController = self.navigationController,
+           navigationController.viewControllers.count > 1 {
+            navigationController.popViewController(animated: true)
+        } else {
+            self.dismiss(animated: true, completion: nil)
         }
+    }
     
-    // MARK:  UINavigationControllerDelegate conformance
+    // MARK: UINavigationControllerDelegate conformance
     
     /// 네비게이션 스택 위치를 기준으로, 스와이프 제스처로 뒤로가기 동작을 설정합니다.
     func navigationController(
         _ navigationController: UINavigationController,
-        didShow viewController: UIViewController, animated: Bool
+        didShow viewController: UIViewController,
+        animated: Bool
     ) {
         navigationController.interactivePopGestureRecognizer?.isEnabled = navigationController.viewControllers.count > 1
     }

--- a/RetsTalk/RetsTalk/Utility/View/BaseViewController.swift
+++ b/RetsTalk/RetsTalk/Utility/View/BaseViewController.swift
@@ -1,0 +1,30 @@
+//
+//  BaseViewController.swift
+//  RetsTalk
+//
+//  Created by HanSeung on 11/27/24.
+//
+
+import UIKit
+
+class BaseViewController: UIViewController, UINavigationControllerDelegate {
+    /// 현재 네비게이션 컨트롤러 상태에 따라 뷰 컨트롤러를 pop 또는 dismiss합니다.
+    func onClickBack() {
+            if let navigationController = self.navigationController,
+                navigationController.viewControllers.count > 1 {
+                navigationController.popViewController(animated: true)
+            } else {
+                self.dismiss(animated: true, completion: nil)
+            }
+        }
+    
+    // MARK:  UINavigationControllerDelegate conformance
+    
+    /// 네비게이션 스택 위치를 기준으로, 스와이프 제스처로 뒤로가기 동작을 설정합니다.
+    func navigationController(
+        _ navigationController: UINavigationController,
+        didShow viewController: UIViewController, animated: Bool
+    ) {
+        navigationController.interactivePopGestureRecognizer?.isEnabled = navigationController.viewControllers.count > 1
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈
###### 없음

## ✨ 세부 내용
현재 모든 뷰는 네비게이션 컨트롤러에 속합니다.
- **BaseViewController**
네비게이션 pop 스와이프 제스처와 뒤로가기 액션의 기본구현을 가지며, 뷰컨트롤러 계층화의 기준이 됩니다.

- **BaseKeyboardViewController**
BaseViewController을 서브클래싱하여 키보드 호출과 소멸에 대한 메서드를 기본구현한 뷰컨트롤러입니다.

- **AlertPresentable**
알림을 띄우는 뷰컨트롤러에 대해 프로토콜과 `func presentAlertpresentAlert(for: , actions: )`의 기본구현을 제공합니다.


## ✍️ 고민한 내용

키보드 호출을 관리하는 기능과 Alert를 띄우는 기능을 둘 다 가져야하는 뷰 컨트롤러에 대해 **다중상속을 받을 수 없으므로**, 키보드 기능과 알림기능에 대해 전부 서브클래싱으로 관리하려면 다음과 같이 세 가지 케이스의 ViewController을 새로 작성해야합니다.

||키보드 기능 O| 키보드 기능 X|
|---|---|---|
|Alert 기능 O|case 1|case 2|
|Alert 기능 X|case 3|BaseViewController|

그러나 이와 같은 구조는 계층화의 의미에서는 벗어난다고 생각하여, 
- 뷰컨트롤러의 생명주기에 관여하는 메소드를 가진 **키보드기능뷰컨트롤러를 계층화**하여 구현하고,
- Alert를 띄우는 기능은 **프로토콜과 기본구현을 제공**하여
문제를 해결했습니다.

## ⌛ 소요 시간
1H30M