### PR TITLE
ViewController의 Lifecycle method 개선 및 BaseHostingViewController

### DIFF
--- a/RetsTalk/RetsTalk/Utility/View/BaseHostingViewController.swift
+++ b/RetsTalk/RetsTalk/Utility/View/BaseHostingViewController.swift
@@ -1,0 +1,40 @@
+//
+//  BaseHostingViewController.swift
+//  RetsTalk
+//
+//  Created by HanSeung on 11/28/24.
+//
+
+import SwiftUI
+
+class BaseHostingViewController<Content: View>: UIHostingController<Content>, UINavigationControllerDelegate {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.navigationController?.delegate = self
+        setupNavigationBar()
+    }
+    
+    func setupNavigationBar() { }
+    
+    // MARK: Navigation handling
+    
+    /// 현재 네비게이션 컨트롤러 상태에 따라 뷰 컨트롤러를 pop 또는 dismiss합니다.
+    func didTapNavigationBackButton() {
+        if let navigationController = self.navigationController,
+           navigationController.viewControllers.count > 1 {
+            navigationController.popViewController(animated: true)
+        } else {
+            self.dismiss(animated: true, completion: nil)
+        }
+    }
+        
+    /// 네비게이션 스택 위치를 기준으로, 스와이프 제스처로 뒤로가기 동작을 설정합니다.
+    func navigationController(
+        _ navigationController: UINavigationController,
+        didShow viewController: UIViewController,
+        animated: Bool
+    ) {
+        navigationController.interactivePopGestureRecognizer?.isEnabled = navigationController.viewControllers.count > 1
+    }
+}

--- a/RetsTalk/RetsTalk/Utility/View/BaseViewController.swift
+++ b/RetsTalk/RetsTalk/Utility/View/BaseViewController.swift
@@ -8,6 +8,28 @@
 import UIKit
 
 class BaseViewController: UIViewController, UINavigationControllerDelegate {
+    
+    // MARK: UIKit lifecycle method
+    
+    override func loadView() { }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.navigationController?.delegate = self
+        setupNavigationBar()
+    }
+    
+    // MARK: RetsTalk lifecycle method
+    
+    func setupNavigationBar() { }
+    
+    // MARK: Navigation handling
+    
     /// 현재 네비게이션 컨트롤러 상태에 따라 뷰 컨트롤러를 pop 또는 dismiss합니다.
     func didTapNavigationBackButton() {
         if let navigationController = self.navigationController,
@@ -17,9 +39,7 @@ class BaseViewController: UIViewController, UINavigationControllerDelegate {
             self.dismiss(animated: true, completion: nil)
         }
     }
-    
-    // MARK: UINavigationControllerDelegate conformance
-    
+        
     /// 네비게이션 스택 위치를 기준으로, 스와이프 제스처로 뒤로가기 동작을 설정합니다.
     func navigationController(
         _ navigationController: UINavigationController,


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

## ✨ 세부 내용
현재 프로젝트 구조에 따라 요구되는 라이프사이클 메서드를 배치했습니다.
다중 상속이 불가하므로 UIHostingController을 서브클래싱하는 BaseHostingViewController를 작성하였습니다.

## ✍️ 고민한 내용

## ⌛ 소요 시간
1H 미만