### PR TITLE
CoreDataManager: init 메서드의 Sendable 핸들러 전달

### DIFF
--- a/RetsTalk/RetsTalk/Persistent/Implementation/CoreDataManager.swift
+++ b/RetsTalk/RetsTalk/Persistent/Implementation/CoreDataManager.swift
@@ -13,7 +13,7 @@ actor CoreDataManager: Persistable {
     
     // MARK: Initialization
     
-    init(inMemory: Bool = false, name: String, completion: @escaping (Result<Void, Swift.Error>) -> Void) {
+    init(inMemory: Bool = false, name: String, completion: @Sendable @escaping (Result<Void, Swift.Error>) -> Void) {
         persistentContainer = NSPersistentContainer(name: name)
         lastHistoryDate = Date()
         


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

## ✨ 세부 내용
코어데이터매니저의 init 메서드의 오류를 수정했습니다.

## ✍️ 고민한 내용


## ⌛ 소요 시간