### PR TITLE
채팅 prepend 기능 추가

### DIFF
--- a/RetsTalk/RetsTalk/Chat/Controller/RetrospectChatViewController.swift
+++ b/RetsTalk/RetsTalk/Chat/Controller/RetrospectChatViewController.swift
@@ -141,7 +141,7 @@ final class RetrospectChatViewController: UIViewController {
     private func subscribeChatEvents() {
         renderingSubject
             .sink(receiveValue: { [weak self] (retrospect, scrollToBottomNeeded) in
-                self?.updateDataSourceDiffrence(from: self?.previousRetrospect?.chat ?? [], to: retrospect.chat)
+                self?.updateDataSourceDifference(from: self?.previousRetrospect?.chat ?? [], to: retrospect.chat)
                 self?.previousRetrospect = retrospect
                 if scrollToBottomNeeded {
                     self?.chatView.scrollToBottom()
@@ -176,9 +176,9 @@ final class RetrospectChatViewController: UIViewController {
     
     @objc private func endChattingButtonTapped() {}
     
-    // MARK: DataSource diffrence managing
+    // MARK: DataSource difference managing
     
-    private func updateDataSourceDiffrence(from source: [Message], to updated: [Message]) {
+    private func updateDataSourceDifference(from source: [Message], to updated: [Message]) {
         var newIndexPaths = [IndexPath]()
         for (index, message) in updated.enumerated() where !source.contains(message) {
             newIndexPaths.append(IndexPath(row: index, section: 0))

--- a/RetsTalk/RetsTalk/Chat/Model/Message.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/Message.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Message {
+struct Message: Hashable {
     let retrospectID: UUID
     let role: Role
     var content: String

--- a/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
@@ -91,7 +91,7 @@ final class RetrospectChatManager: RetrospectChatManageable {
     
     private func recentMessageFetchRequest(offset: Int, amount: Int) -> PersistFetchRequest<Message> {
         let matchingRetorspect = CustomPredicate(format: Texts.matchingRetorspect, argumentArray: [retrospect.id])
-        let recentDateSorting = CustomSortDescriptor(key: Texts.matchingRetorspect, ascending: false)
+        let recentDateSorting = CustomSortDescriptor(key: Texts.messageSortKey, ascending: false)
         let request = PersistFetchRequest<Message>(
             predicate: matchingRetorspect,
             sortDescriptors: [recentDateSorting],

--- a/RetsTalk/RetsTalk/Chat/View/ChatView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/ChatView.swift
@@ -36,12 +36,6 @@ final class ChatView: UIView {
         chattingTableViewSetUp()
     }
     
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        scrollToBottom()
-    }
-    
     private func messageInputViewSetUp() {
         addSubview(messageInputView)
         
@@ -72,6 +66,7 @@ final class ChatView: UIView {
     private func chattingTableViewSetUp() {
         addSubview(chattingTableView)
         
+        chattingTableView.scrollsToTop = false
         chattingTableView.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
@@ -112,10 +107,10 @@ final class ChatView: UIView {
     }
 
     func insertMessages(at indexPaths: [IndexPath]) {
-        chattingTableView.performBatchUpdates {
-            chattingTableView.insertRows(at: indexPaths, with: .bottom)
-            scrollToBottom()
-        }
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        chattingTableView.insertRows(at: indexPaths, with: .none)
+        CATransaction.commit()
     }
 
     func updateRequestInProgressState(_ state: Bool) {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #80 

## ✨ 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

### 16 Pro (iOS18.1)

https://github.com/user-attachments/assets/e5efe76b-18f1-4e7a-9975-227ad9ab41d6

### SE (iOS16.0)

https://github.com/user-attachments/assets/3e5192af-72a3-4247-b63e-2f83c3ace08c 

## ✍️ 고민한 내용

<!-- 해당 PR중 고민한 내용이 있으면 적어주세요. -->

테이블 뷰를 위로 스크롤 하며, 위에 데이터를 추가할 경우, 테이블 뷰가 이에 대응하는 동안 스크롤 오프셋이 튀는 현상이 발생합니다.

오프셋이 튀면, 불필요한 추가 요청이 발생할 수 있고 그러면 더 심하게 오프셋이 튑니다.

테이블 뷰를 업데이트할 때 오프셋이 변하지 않도록 강제하는 것이 필요한데, 다음의 코드가 이를 만족해줍니다.

```swift
CATransaction.begin()
CATransaction.setDisableActions(true)
chattingTableView.insertRows(at: indexPaths, with: .none)
CATransaction.commit()
```

아직 정확한 이유는 모르지만,

CoreAnimation 수준에서 원자적으로 작업을 수행하고, 애니메이션을 비활성화해서 오프셋이 그대로 유지되도록 처리되는 것으로 보입니다.

추가로 추가 요청은, 테이블 뷰의 컨텐츠 크기와 시간 그리고 드래깅 여부로 판단해서 최대한 불필요한 중복을 제거했습니다.

```swift
static func == (lhs: ScrollInfo, rhs: ScrollInfo) -> Bool {
    let isDragging = lhs.isDragging || rhs.isDragging
    let isContentHeightDiffInsignificant = abs(lhs.contentHeight - rhs.contentHeight) / 100 < 0
    let isTimeDiffInsignificant = abs(lhs.time.timeIntervalSince(rhs.time)) < 0.1
    return isDragging || isContentHeightDiffInsignificant || isTimeDiffInsignificant
}
```

그리고 removeDuplicates 처리.

## ⌛ 소요 시간

2d