### PR TITLE
UserSettingManager: 사용자 ID 반환/부여하는 기능

### DIFF
--- a/RetsTalk/RetsTalk/User/Model/UserData.swift
+++ b/RetsTalk/RetsTalk/User/Model/UserData.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct UserData {
+    var userID: String
     var isCloudSyncOn: Bool
     var isNotificationOn: Bool
     var notificationTime: Date
@@ -20,6 +21,7 @@ struct UserData {
 extension UserData: EntityRepresentable {
     var mappingDictionary: [String: Any] {
         [
+            "userID": userID,
             "isCloudSyncOn": isCloudSyncOn,
             "isNotificationOn": isNotificationOn,
             "notificationTime": notificationTime,
@@ -29,6 +31,7 @@ extension UserData: EntityRepresentable {
     }
     
     init(dictionary: [String: Any]) {
+        userID = dictionary["userID"] as? String ?? ""
         isCloudSyncOn = dictionary["isCloudSyncOn"] as? Bool ?? false
         isNotificationOn = dictionary["isNotificationOn"] as? Bool ?? false
         notificationTime = dictionary["notificationTime"] as? Date ?? Date()

--- a/RetsTalk/RetsTalk/User/Model/UserSettingManageable.swift
+++ b/RetsTalk/RetsTalk/User/Model/UserSettingManageable.swift
@@ -10,7 +10,16 @@ import Foundation
 
 protocol UserSettingManageable: Sendable {
     var userData: UserData { get }
-
+    
+    /// 사용자 정보를 초기화하거나 가져오는 함수입니다.
+    ///
+    /// 비동기적으로 저장된 사용자 정보를 가져오고 아이디를 반환합니다.
+    /// 만약 정보가 없으면, 새로운 사용자 정보를 저장하고 반환합니다.
+    /// - Returns: 사용자 아이디
+    func initialize() async -> UUID?
+    /// 로컬 저장소의 사용자 데이터를 가져옵니다.
     func fetch()
+    /// 로컬 저장소의 사용자 정보를 업데이트합니다.
+    /// - Parameter userData: 새로 업데이트하는 사용자 정보
     func update(to userData: UserData)
 }

--- a/RetsTalk/RetsTalk/User/Model/UserSettingManager.swift
+++ b/RetsTalk/RetsTalk/User/Model/UserSettingManager.swift
@@ -57,7 +57,7 @@ final class UserSettingManager: UserSettingManageable, @unchecked Sendable, Obse
         }
     }
     
-    // MARK: Custom method
+    // MARK: Creating UserData Method
 
     private func initializeUserData() -> UUID {
         let newUserID = UUID()
@@ -71,7 +71,6 @@ final class UserSettingManager: UserSettingManageable, @unchecked Sendable, Obse
                 userData = addedData
             }
         }
-        
         return newUserID
     }
     

--- a/RetsTalk/RetsTalk/User/Model/UserSettingManager.swift
+++ b/RetsTalk/RetsTalk/User/Model/UserSettingManager.swift
@@ -25,9 +25,7 @@ final class UserSettingManager: UserSettingManageable, @unchecked Sendable, Obse
             let request = PersistFetchRequest<UserData>(fetchLimit: 1)
             let fetchedData = try await userDataStorage.fetch(by: request)
             guard let storedUserData = fetchedData.first
-            else {
-                return initializeUserData()
-            }
+            else { return initializeUserData() }
 
             await MainActor.run {
                 userData = storedUserData

--- a/RetsTalk/RetsTalk/User/Model/UserSettingManager.swift
+++ b/RetsTalk/RetsTalk/User/Model/UserSettingManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Foundation
 
 final class UserSettingManager: UserSettingManageable, @unchecked Sendable, ObservableObject {
     @Published var userData: UserData = .init(dictionary: [:])
@@ -19,17 +20,32 @@ final class UserSettingManager: UserSettingManageable, @unchecked Sendable, Obse
     
     // MARK: UserSettingManageable conformance
     
+    func initialize() async -> UUID? {
+        do {
+            let request = PersistFetchRequest<UserData>(fetchLimit: 1)
+            let fetchedData = try await userDataStorage.fetch(by: request)
+            guard let storedUserData = fetchedData.first
+            else {
+                return initializeUserData()
+            }
+
+            await MainActor.run {
+                userData = storedUserData
+            }
+            return UUID(uuidString: userData.userID)
+        } catch {
+            return nil
+        }
+    }
+    
     func fetch() {
         let request = PersistFetchRequest<UserData>(fetchLimit: 1)
         Task {
             let fetchedData = try await userDataStorage.fetch(by: request)
-            guard fetchedData.isNotEmpty, let fetchedData = fetchedData.first else {
-                initiateUserData()
-                return
-            }
+            guard let storedUserData = fetchedData.first else { return }
             
             await MainActor.run {
-                userData = fetchedData
+                userData = storedUserData
             }
         }
     }
@@ -43,12 +59,39 @@ final class UserSettingManager: UserSettingManageable, @unchecked Sendable, Obse
         }
     }
     
-    private func initiateUserData() {
+    // MARK: Custom method
+
+    private func initializeUserData() -> UUID {
+        let newUserID = UUID()
+        let newNickname = randomNickname()
+        let newUserData = UserData(dictionary: ["userID": newUserID.uuidString, "nickname": newNickname])
         Task {
-            let addedData = try await userDataStorage.add(contentsOf: [UserData(dictionary: [:])])
+            let addedData = try await userDataStorage.add(contentsOf: [newUserData])
             guard let addedData = addedData.first else { return }
             
-            userData = addedData
+            await MainActor.run {
+                userData = addedData
+            }
         }
+        
+        return newUserID
+    }
+    
+    private func randomNickname() -> String {
+        let adjective = Texts.nicknameComposingAdjectives.randomElement() ?? ""
+        let noun = Texts.nicknameComposingNoun
+        return adjective + " " + noun
+    }
+}
+
+// MARK: - Constants
+
+private extension UserSettingManager {
+    enum Texts {
+        static let nicknameComposingAdjectives = [
+            "게임하는", "산책하는", "야근하는", "공상하는",
+            "폭식하는", "달리는", "춤추는", "헤엄치는", "노래하는",
+        ]
+        static let nicknameComposingNoun = "부덕이"
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #151 
- closed: #152 
- closed: #153 

## ✨ 세부 내용
앱 진입 시점에서 사용자 설정 정보의 아이디를 가져오는 작업이 필수적으로 요구됩니다.
UserSettingManageable의 `initialize()` 메서드는 UserDefaults에 저장된 사용자 정보를 가져오고 아이디를 반환합니다.
만약 정보가 없으면, 새로운 사용자 정보를 저장하고 반환합니다.
이 작업은 비동기적으로 이루어지며, 앱 진입 시점에 Task 블록을 통해 비동기작업을 수행합니다.

추가적으로, UserDefaults는 UUID 타입을 저장할 수 없어 문자열로 변환해 저장하도록 했습니다.
앱 진입시점 이외에, UserSettingManager을 통한 userID 접근이 필요할 경우에는 반환타입이 `String`임을 미리 알립니다.

## ✍️ 고민한 내용
앱 진입 시점에서 사용자 설정 정보를 가져오는 비동기작업이 필수이므로, 해당 작업이 진행되는 동안 (매우 잠시) 화면이 표시되지 않는 모습을 보였습니다. 잠깐 검은 화면을 띄운 후에 회고목록화면이 보이므로, 스플래시 화면이 필요할 것으로 예상됩니다.
<!-- 해당 PR중 고민한 내용이 있으면 적어주세요. -->

## ⌛ 소요 시간
2H