### PR TITLE
Persistent, Network 영역에 격리를 없애고 각 부분에 맞는 격리로 되도록 개선

### DIFF
--- a/RetsTalk/RetsTalk/Chat/Model/AssistantMessageProvider.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/AssistantMessageProvider.swift
@@ -5,6 +5,6 @@
 //  Created on 11/19/24.
 //
 
-protocol AssistantMessageProvidable: Actor {
+protocol AssistantMessageProvidable: Sendable {
     func requestAssistantMessage(for chat: [Message]) async throws -> Message
 }

--- a/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
@@ -9,7 +9,7 @@ import Foundation
 
 final class RetrospectChatManager: RetrospectChatManageable {
     private(set) var retrospect: Retrospect {
-        didSet { retrospectChatManagerListener.didUpdateRetrospect(self, retrospect: retrospect) }
+        didSet { try? retrospectChatManagerListener.didUpdateRetrospect(self, retrospect: retrospect) }
     }
     private(set) var errorOccurred: Swift.Error?
     

--- a/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
@@ -51,7 +51,7 @@ final class RetrospectChatManager: RetrospectChatManageable {
         await requestAssistentMessage()
     }
     
-    func fetchPreviousMessages() async {
+    func fetchPreviousMessages() {
         do {
             let request = recentMessageFetchRequest(offset: retrospect.chat.count, amount: Numeric.messageFetchAmount)
             let fetchedMessages = try messageStorage.fetch(by: request)

--- a/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
@@ -37,7 +37,7 @@ final class RetrospectChatManager: RetrospectChatManageable {
     func sendMessage(_ text: String) async {
         do {
             let userMessage = Message(retrospectID: retrospect.id, role: .user, content: text)
-            let addedUserMessage = try await messageStorage.add(contentsOf: [userMessage])
+            let addedUserMessage = try messageStorage.add(contentsOf: [userMessage])
             retrospect.append(contentsOf: addedUserMessage)
         } catch {
             errorOccurred = error
@@ -54,7 +54,7 @@ final class RetrospectChatManager: RetrospectChatManageable {
     func fetchPreviousMessages() async {
         do {
             let request = recentMessageFetchRequest(offset: retrospect.chat.count, amount: Numeric.messageFetchAmount)
-            let fetchedMessages = try await messageStorage.fetch(by: request)
+            let fetchedMessages = try messageStorage.fetch(by: request)
             retrospect.prepend(contentsOf: fetchedMessages)
         } catch {
             errorOccurred = error
@@ -80,7 +80,7 @@ final class RetrospectChatManager: RetrospectChatManageable {
     private func requestAssistentMessage() async {
         do {
             let assistantMessage = try await assistantMessageProvider.requestAssistantMessage(for: retrospect.chat)
-            let addedAssistantMessage = try await messageStorage.add(contentsOf: [assistantMessage])
+            let addedAssistantMessage = try messageStorage.add(contentsOf: [assistantMessage])
             retrospect.append(contentsOf: addedAssistantMessage)
             retrospect.status = .inProgress(.waitingForUserInput)
         } catch {

--- a/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManagerListener.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManagerListener.swift
@@ -7,6 +7,6 @@
 
 @RetrospectActor
 protocol RetrospectChatManagerListener {
-    func didUpdateRetrospect(_ retrospectChatManageable: RetrospectChatManageable, retrospect: Retrospect)
+    func didUpdateRetrospect(_ retrospectChatManageable: RetrospectChatManageable, retrospect: Retrospect) throws
     func shouldTogglePin(_ retrospectChatManageable: RetrospectChatManageable, retrospect: Retrospect) -> Bool
 }

--- a/RetsTalk/RetsTalk/Network/CLOVAStudio/CLOVAStudioManager.swift
+++ b/RetsTalk/RetsTalk/Network/CLOVAStudio/CLOVAStudioManager.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-actor CLOVAStudioManager: NetworkRequestable {
+final class CLOVAStudioManager: NetworkRequestable {
     let urlSession: URLSession
     
     init(urlSession: URLSession) {

--- a/RetsTalk/RetsTalk/Network/NetworkRequestable.swift
+++ b/RetsTalk/RetsTalk/Network/NetworkRequestable.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol NetworkRequestable: Actor {
+protocol NetworkRequestable: Sendable {
     var urlSession: URLSession { get }
     
     func request(with urlRequestComposer: any URLRequestComposable) async throws -> Data

--- a/RetsTalk/RetsTalk/Persistent/Implementation/CoreDataManager.swift
+++ b/RetsTalk/RetsTalk/Persistent/Implementation/CoreDataManager.swift
@@ -7,7 +7,7 @@
 
 @preconcurrency import CoreData
 
-final class CoreDataManager: Persistable {
+final class CoreDataManager: Persistable, @unchecked Sendable {
     private let persistentContainer: NSPersistentCloudKitContainer
     private var lastHistoryDate: Date
     

--- a/RetsTalk/RetsTalk/Persistent/Implementation/UserDefaultsManager.swift
+++ b/RetsTalk/RetsTalk/Persistent/Implementation/UserDefaultsManager.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-actor UserDefaultsManager: Persistable {
+final class UserDefaultsManager: Persistable {
     private let userDefaultsContainer: UserDefaults
 
     init(container: UserDefaults = .standard) {

--- a/RetsTalk/RetsTalk/Persistent/Implementation/UserDefaultsManager.swift
+++ b/RetsTalk/RetsTalk/Persistent/Implementation/UserDefaultsManager.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class UserDefaultsManager: Persistable {
+final class UserDefaultsManager: Persistable, @unchecked Sendable {
     private let userDefaultsContainer: UserDefaults
 
     init(container: UserDefaults = .standard) {

--- a/RetsTalk/RetsTalk/Persistent/Persistable.swift
+++ b/RetsTalk/RetsTalk/Persistent/Persistable.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol Persistable {
+protocol Persistable: Sendable {
     /// 로컬 저장소에 엔티티 데이터를 추가합니다.
     /// - Parameter entities: 추가할 엔티티 배열.
     /// - Returns: 추가된 데이터.

--- a/RetsTalk/RetsTalk/Persistent/Persistable.swift
+++ b/RetsTalk/RetsTalk/Persistent/Persistable.swift
@@ -7,17 +7,17 @@
 
 import Foundation
 
-protocol Persistable: Actor {
+protocol Persistable {
     /// 로컬 저장소에 엔티티 데이터를 추가합니다.
     /// - Parameter entities: 추가할 엔티티 배열.
     /// - Returns: 추가된 데이터.
-    func add<Entity>(contentsOf entities: [Entity]) async throws -> [Entity] where Entity: EntityRepresentable
+    func add<Entity>(contentsOf entities: [Entity]) throws -> [Entity] where Entity: EntityRepresentable
     /// 로컬 저장소에서 요청 조건에 맞는 엔티티 데이터를 불러옵니다.
     /// - Parameter request: 요청 조건.
     /// - Returns: 엔티티 데이터.
     func fetch<Entity>(
         by request: any PersistFetchRequestable<Entity>
-    ) async throws -> [Entity] where Entity: EntityRepresentable
+    ) throws -> [Entity] where Entity: EntityRepresentable
     /// 로컬 저장소의 엔티티 데이터에 대한 최신화를 수행합니다.
     /// - Parameters:
     ///   - entity: 최신화할 엔티티 값.
@@ -26,8 +26,8 @@ protocol Persistable: Actor {
     func update<Entity>(
         from sourceEntity: Entity,
         to updatingEntity: Entity
-    ) async throws -> Entity where Entity: EntityRepresentable
+    ) throws -> Entity where Entity: EntityRepresentable
     /// 로컬 저장소에서 엔티티 데이터를 제거합니다.
     /// - Parameter entities: 제거할 엔티티 데이터.
-    func delete<Entity>(contentsOf entities: [Entity]) async throws where Entity: EntityRepresentable
+    func delete<Entity>(contentsOf entities: [Entity]) throws where Entity: EntityRepresentable
 }

--- a/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectListViewController.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectListViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 
 final class RetrospectListViewController: BaseViewController {
     private let retrospectManager: RetrospectManageable
-    private let userDefaultsManager: UserDefaultsManager
+    private let userDefaultsManager: Persistable
     private let userSettingManager: UserSettingManager
 
     private var subscriptionSet: Set<AnyCancellable>
@@ -22,7 +22,7 @@ final class RetrospectListViewController: BaseViewController {
     
     init(
         retrospectManager: RetrospectManageable,
-        userDefaultsManager: UserDefaultsManager
+        userDefaultsManager: Persistable
     ) {
         self.retrospectManager = retrospectManager
         self.userDefaultsManager = userDefaultsManager

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -68,7 +68,7 @@ final class RetrospectManager: RetrospectManageable {
         return retrospectChatManager
     }
     
-    func fetchRetrospects(of kindSet: Set<Retrospect.Kind>) async {
+    func fetchRetrospects(of kindSet: Set<Retrospect.Kind>) {
         do {
             for kind in kindSet {
                 let request = retrospectFetchRequest(for: kind)
@@ -83,7 +83,7 @@ final class RetrospectManager: RetrospectManageable {
         }
     }
     
-    func togglePinRetrospect(_ retrospect: Retrospect) async {
+    func togglePinRetrospect(_ retrospect: Retrospect) {
         do {
             guard retrospect.isPinned || isPinAvailable else { throw Error.reachInProgressLimit }
             
@@ -110,7 +110,7 @@ final class RetrospectManager: RetrospectManageable {
         }
     }
     
-    func deleteRetrospect(_ retrospect: Retrospect) async {
+    func deleteRetrospect(_ retrospect: Retrospect) {
         do {
             try retrospectStorage.delete(contentsOf: [retrospect])
             retrospects.removeAll(where: { $0.id == retrospect.id })

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -180,9 +180,9 @@ extension RetrospectManager: RetrospectChatManagerListener {
         guard let matchingIndex = retrospects.firstIndex(where: { $0.id == retrospect.id })
         else { return }
         
-        _ = try retrospectStorage.update(from: retrospects[matchingIndex], to: retrospect)
+        let updatedRetrospect = try retrospectStorage.update(from: retrospects[matchingIndex], to: retrospect)
         
-        retrospects[matchingIndex] = retrospect
+        retrospects[matchingIndex] = updatedRetrospect
     }
     
     func shouldTogglePin(_ retrospectChatManageable: RetrospectChatManageable, retrospect: Retrospect) -> Bool {

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -72,7 +72,7 @@ final class RetrospectManager: RetrospectManageable {
         do {
             for kind in kindSet {
                 let request = retrospectFetchRequest(for: kind)
-                let fetchedRetrospects = try await retrospectStorage.fetch(by: request)
+                let fetchedRetrospects = try retrospectStorage.fetch(by: request)
                 for retrospect in fetchedRetrospects where !retrospects.contains(retrospect) {
                     retrospects.append(retrospect)
                 }
@@ -89,7 +89,7 @@ final class RetrospectManager: RetrospectManageable {
             
             var updatingRetrospect = retrospect
             updatingRetrospect.isPinned.toggle()
-            let updatedRetrospect = try await retrospectStorage.update(from: retrospect, to: updatingRetrospect)
+            let updatedRetrospect = try retrospectStorage.update(from: retrospect, to: updatingRetrospect)
             updateRetrospects(by: updatedRetrospect)
             errorOccurred = nil
         } catch {
@@ -102,7 +102,7 @@ final class RetrospectManager: RetrospectManageable {
             var updatingRetrospect = retrospect
             updatingRetrospect.summary = try await retrospectAssistantProvider.requestSummary(for: retrospect.chat)
             updatingRetrospect.status = .finished
-            let updatedRetrospect = try await retrospectStorage.update(from: retrospect, to: updatingRetrospect)
+            let updatedRetrospect = try retrospectStorage.update(from: retrospect, to: updatingRetrospect)
             updateRetrospects(by: updatedRetrospect)
             errorOccurred = nil
         } catch {
@@ -112,7 +112,7 @@ final class RetrospectManager: RetrospectManageable {
     
     func deleteRetrospect(_ retrospect: Retrospect) async {
         do {
-            try await retrospectStorage.delete(contentsOf: [retrospect])
+            try retrospectStorage.delete(contentsOf: [retrospect])
             retrospects.removeAll(where: { $0.id == retrospect.id })
             errorOccurred = nil
         } catch {
@@ -132,7 +132,7 @@ final class RetrospectManager: RetrospectManageable {
         var newRetrospect = Retrospect(userID: userID)
         let initialAssistentMessage = try await requestInitialAssistentMessage(for: newRetrospect)
         newRetrospect.append(contentsOf: [initialAssistentMessage])
-        guard let addedRetrospect = try await retrospectStorage.add(contentsOf: [newRetrospect]).first
+        guard let addedRetrospect = try retrospectStorage.add(contentsOf: [newRetrospect]).first
         else { throw Error.creationFailed }
         
         return addedRetrospect

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -176,13 +176,12 @@ final class RetrospectManager: RetrospectManageable {
 // MARK: - RetrospectChatManagerListener conformance
 
 extension RetrospectManager: RetrospectChatManagerListener {
-    func didUpdateRetrospect(_ retrospectChatManageable: RetrospectChatManageable, retrospect: Retrospect) {
+    func didUpdateRetrospect(_ retrospectChatManageable: RetrospectChatManageable, retrospect: Retrospect) throws {
         guard let matchingIndex = retrospects.firstIndex(where: { $0.id == retrospect.id })
         else { return }
         
-        Task {
-            try await retrospectStorage.update(from: retrospects[matchingIndex], to: retrospect)
-        }
+        _ = try retrospectStorage.update(from: retrospects[matchingIndex], to: retrospect)
+        
         retrospects[matchingIndex] = retrospect
     }
     

--- a/RetsTalk/RetsTalk/Retrospect/Model/SummaryProvider.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/SummaryProvider.swift
@@ -5,6 +5,6 @@
 //  Created by KimMinSeok on 11/21/24.
 //
 
-protocol SummaryProvider {
+protocol SummaryProvider: Sendable {
     func requestSummary(for chat: [Message]) async throws -> String
 }

--- a/RetsTalk/RetsTalk/User/Model/UserSettingManager.swift
+++ b/RetsTalk/RetsTalk/User/Model/UserSettingManager.swift
@@ -23,7 +23,7 @@ final class UserSettingManager: UserSettingManageable, @unchecked Sendable, Obse
     func initialize() async -> UUID? {
         do {
             let request = PersistFetchRequest<UserData>(fetchLimit: 1)
-            let fetchedData = try await userDataStorage.fetch(by: request)
+            let fetchedData = try userDataStorage.fetch(by: request)
             guard let storedUserData = fetchedData.first
             else { return initializeUserData() }
             
@@ -39,7 +39,7 @@ final class UserSettingManager: UserSettingManageable, @unchecked Sendable, Obse
     func fetch() {
         let request = PersistFetchRequest<UserData>(fetchLimit: 1)
         Task {
-            let fetchedData = try await userDataStorage.fetch(by: request)
+            let fetchedData = try userDataStorage.fetch(by: request)
             guard let storedUserData = fetchedData.first else { return }
             
             await MainActor.run {
@@ -71,7 +71,7 @@ final class UserSettingManager: UserSettingManageable, @unchecked Sendable, Obse
     
     private func update(to updatingData: UserData) {
         Task {
-            let updatedData = try await userDataStorage.update(from: updatingData, to: updatingData)
+            let updatedData = try userDataStorage.update(from: updatingData, to: updatingData)
             await MainActor.run {
                 userData = updatedData
             }
@@ -83,7 +83,7 @@ final class UserSettingManager: UserSettingManageable, @unchecked Sendable, Obse
         let newNickname = randomNickname()
         let newUserData = UserData(dictionary: ["userID": newUserID.uuidString, "nickname": newNickname])
         Task {
-            let addedData = try await userDataStorage.add(contentsOf: [newUserData])
+            let addedData = try userDataStorage.add(contentsOf: [newUserData])
             guard let addedData = addedData.first else { return }
             
             await MainActor.run {
@@ -95,7 +95,7 @@ final class UserSettingManager: UserSettingManageable, @unchecked Sendable, Obse
     
     private func initiateUserData() {
         Task {
-            let addedData = try await userDataStorage.add(contentsOf: [UserData(dictionary: [:])])
+            let addedData = try userDataStorage.add(contentsOf: [UserData(dictionary: [:])])
             guard let addedData = addedData.first else { return }
             
             await MainActor.run {


### PR DESCRIPTION
##  📌 관련 이슈

- closed: #176 

## ✨ 세부 내용

### Network 영역 Actor 제거

Network 영역에 Network 요청 부분을 아래와 같이 Sendable하게 만들었습니다.

|NetworkRequestable|AssistantMessageProvidable|SummaryProvider|
|---|---|---|
|<img width="481" alt="image" src="https://github.com/user-attachments/assets/af17dae9-7fcb-4093-bffa-8661ed2dbfba">|<img width="678" alt="image" src="https://github.com/user-attachments/assets/9afddc4e-508a-40c6-a75a-02905e52c7bb">|<img width="608" alt="image" src="https://github.com/user-attachments/assets/0d853995-b713-47fc-a739-5aad108947ba">|

위와 같이 Sendable하게 만들고 아래처럼 사용하는 부분에 Actor에 맞게 되도록 했습니다

-> `모든 Actor 타입은 Sendable함!`

<br><br><br>

<img width="704" alt="image" src="https://github.com/user-attachments/assets/6171d738-b5a3-4bf1-b970-fc7445398581">

그렇게 변경됨에 따라 회고 Actor에서 네트워크 요청을 Provider를 통해 비동기적으로 받아오고 있습니다.

<br><br><br>

### Persistent 영역 Actor 제거

아래와 같이 인스턴스가 각 구현체에 맞게 격리 되도록 했습니다.
|Retrospect Actor|Main Actor|
|---|---|
|<img width="662" alt="image" src="https://github.com/user-attachments/assets/f0e40484-1ccc-4a32-a680-05636763ed0f">|<img width="606" alt="image" src="https://github.com/user-attachments/assets/d87f75be-fbf9-448d-86f8-e934ed32b9f2">|

<br><br><br><br><br>

<!-- 수정/추가한 내용을 적어주세요. -->

## ✍️ 고민한 내용
### Persistable에 Sendable을 채택한 후 문제

### CoreData 
이제 `perform`에서 `performAndWait`로 동기적으로 작동을 할텐데 
History를 남기고 해당 부분을 관리하는 부분이 var로 선언 되어 있어서 안전하지 않다고 될텐데
이 부분을 `@unchecked Sendable`을 채택해야할지 고민 중입니다.
저 부분을 unchecked로 하면 동시성을 컴파일러에서 수행하는게 아닌
저희가 동시적으로 접근을 안한다는 보장을 무조건 해줘야해서 방향성이 맞지 않아서 어떡할지 고민 중입니다.

### UserDefault
UserDefault도 Sendable을 채택하고 있어서 
`private let userDefaultsContainer: UserDefaults` 이 부분이 문제입니다.
userDefaults 부분이 class로 되어 있어서 안전하지 않을텐데 해당 부분도 위와 같이 고민 중입니다.

<!-- 해당 PR중 고민한 내용이 있으면 적어주세요. -->

## ⌛ 소요 시간
3h