### PR TITLE
베이스 뷰 컨트롤로 및 뷰 개선(#178)

### DIFF
--- a/RetsTalk/RetsTalk/Utility/View/BaseHostingViewController.swift
+++ b/RetsTalk/RetsTalk/Utility/View/BaseHostingViewController.swift
@@ -7,34 +7,14 @@
 
 import SwiftUI
 
-class BaseHostingViewController<Content: View>: UIHostingController<Content>, UINavigationControllerDelegate {
+class BaseHostingViewController<Content: View>: UIHostingController<Content> {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        navigationController?.delegate = self
         setupNavigationBar()
     }
     
-    func setupNavigationBar() { }
-    
-    // MARK: Navigation handling
-    
-    /// 현재 네비게이션 컨트롤러 상태에 따라 뷰 컨트롤러를 pop 또는 dismiss합니다.
-    func didTapNavigationBackButton() {
-        if let navigationController = self.navigationController,
-           navigationController.viewControllers.count > 1 {
-            navigationController.popViewController(animated: true)
-        } else {
-            dismiss(animated: true, completion: nil)
-        }
-    }
-        
-    /// 네비게이션 스택 위치를 기준으로, 스와이프 제스처로 뒤로가기 동작을 설정합니다.
-    func navigationController(
-        _ navigationController: UINavigationController,
-        didShow viewController: UIViewController,
-        animated: Bool
-    ) {
-        navigationController.interactivePopGestureRecognizer?.isEnabled = navigationController.viewControllers.count > 1
+    func setupNavigationBar() {
+        navigationController?.navigationBar.tintColor = .blazingOrange
     }
 }

--- a/RetsTalk/RetsTalk/Utility/View/BaseKeyBoardViewController.swift
+++ b/RetsTalk/RetsTalk/Utility/View/BaseKeyBoardViewController.swift
@@ -8,49 +8,50 @@
 import UIKit
 
 class BaseKeyBoardViewController: BaseViewController {
+    
+    // MARK: ViewController lifecycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        addKeyboardObservers()
-        addTapGestureOfDismissingKeyboard()
+        addKeyboardNotificationObservers()
     }
     
-    // MARK: TapGesture of KeyboardDismissing
+    // MARK: Keyboard observing
     
-    private func addTapGestureOfDismissingKeyboard() {
-        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
-        view.addGestureRecognizer(tapGestureRecognizer)
-    }
-    
-    @objc private func dismissKeyboard() {
-        view.endEditing(true)
-    }
-    
-    // MARK: KeyboardObserving
-    
-    private func addKeyboardObservers() {
+    private func addKeyboardNotificationObservers() {
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(keyboardWillShowAndHide(_:)),
+            selector: #selector(keyboardWillShow(_:)),
             name: UIResponder.keyboardWillShowNotification,
             object: nil
         )
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(keyboardWillShowAndHide(_:)),
+            selector: #selector(keyboardWillHide(_:)),
             name: UIResponder.keyboardWillHideNotification,
             object: nil
         )
     }
     
-    @objc private func keyboardWillShowAndHide(_ notification: Notification) {
-        if let userInfo = notification.userInfo,
-           let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
-            keyboardWillUpdateConstraint(keyboardHeight: keyboardFrame.height)
-        }
+    // MARK: Keyboard event hanler
+    
+    @objc
+    private func keyboardWillShow(_ notification: Notification) {
+        guard let keywordInfo = KeyboardInfo(notification: notification) else { return }
+        
+        handleKeyboardWillShowEvent(using: keywordInfo)
     }
     
-    /// 이 함수는 키보드 호출 시 높이를 전달받아 레이아웃을 조정합니다.
-    /// - Parameter keyboardHeight: 키보드 높이
-    func keyboardWillUpdateConstraint(keyboardHeight: CGFloat) { }
+    @objc
+    private func keyboardWillHide(_ notification: Notification) {
+        guard var keywordInfo = KeyboardInfo(notification: notification) else { return }
+        
+        keywordInfo.frame = CGRect()
+        handleKeyboardWillHideEvent(using: keywordInfo)
+    }
+    
+    func handleKeyboardWillShowEvent(using keyboardInfo: KeyboardInfo) {}
+    
+    func handleKeyboardWillHideEvent(using keyboardInfo: KeyboardInfo) {}
 }

--- a/RetsTalk/RetsTalk/Utility/View/BaseView.swift
+++ b/RetsTalk/RetsTalk/Utility/View/BaseView.swift
@@ -1,0 +1,37 @@
+//
+//  BaseView.swift
+//  RetsTalk
+//
+//  Created on 12/2/24.
+//
+
+import UIKit
+
+class BaseView: UIView {
+    
+    // MARK: Initialization
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupStyles()
+        setupSubviews()
+        setupSubviewLayouts()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        setupStyles()
+        setupSubviews()
+        setupSubviewLayouts()
+    }
+    
+    // MARK: RetsTalk lifecycle
+    
+    func setupStyles() {}
+    
+    func setupSubviews() {}
+    
+    func setupSubviewLayouts() {}
+}

--- a/RetsTalk/RetsTalk/Utility/View/BaseViewController.swift
+++ b/RetsTalk/RetsTalk/Utility/View/BaseViewController.swift
@@ -5,43 +5,57 @@
 //  Created by HanSeung on 11/27/24.
 //
 
+import Combine
 import UIKit
 
-class BaseViewController: UIViewController, UINavigationControllerDelegate {
+class BaseViewController: UIViewController {
+    private var subscriptionSet: Set<AnyCancellable>
     
-    // MARK: UIKit lifecycle method
+    // MARK: Initialization
     
-    override func loadView() { }
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        subscriptionSet = []
+        
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
+    
+    required init?(coder: NSCoder) {
+        subscriptionSet = []
+        
+        super.init(coder: coder)
+    }
+    
+    // MARK: ViewController lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupDelegation()
+        setupDataSource()
+    }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        navigationController?.delegate = self
         setupNavigationBar()
+        setupSubscription(on: &subscriptionSet)
     }
     
-    // MARK: RetsTalk lifecycle method
-    
-    func setupNavigationBar() { }
-    
-    // MARK: Navigation handling
-    
-    /// 현재 네비게이션 컨트롤러 상태에 따라 뷰 컨트롤러를 pop 또는 dismiss합니다.
-    func didTapNavigationBackButton() {
-        if let navigationController = self.navigationController,
-           navigationController.viewControllers.count > 1 {
-            navigationController.popViewController(animated: true)
-        } else {
-            dismiss(animated: true, completion: nil)
-        }
-    }
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         
-    /// 네비게이션 스택 위치를 기준으로, 스와이프 제스처로 뒤로가기 동작을 설정합니다.
-    func navigationController(
-        _ navigationController: UINavigationController,
-        didShow viewController: UIViewController,
-        animated: Bool
-    ) {
-        navigationController.interactivePopGestureRecognizer?.isEnabled = navigationController.viewControllers.count > 1
+        subscriptionSet.removeAll()
     }
+    
+    // MARK: RetsTalk lifecycle
+    
+    func setupDelegation() {}
+    
+    func setupDataSource() {}
+    
+    func setupNavigationBar() {
+        navigationController?.navigationBar.tintColor = .blazingOrange
+    }
+    
+    func setupSubscription(on subscriptionSet: inout Set<AnyCancellable>) {}
 }

--- a/RetsTalk/RetsTalk/Utility/View/KeyboardInfo.swift
+++ b/RetsTalk/RetsTalk/Utility/View/KeyboardInfo.swift
@@ -1,0 +1,23 @@
+//
+//  KeyboardInfo.swift
+//  RetsTalk
+//
+//  Created by Byeongjo Koo on 12/2/24.
+//
+
+import UIKit
+
+struct KeyboardInfo {
+    var frame: CGRect
+    let animationDuration: TimeInterval
+    
+    init?(notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let frame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+              let animationDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval
+        else { return nil }
+        
+        self.frame = frame
+        self.animationDuration = animationDuration
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- close: #178 

## ✨ 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

뷰 컨트롤러와 뷰에서 발생하는 기본적인 사이클을 재정의 했습니다.

## ✍️ 고민한 내용

<!-- 해당 PR중 고민한 내용이 있으면 적어주세요. -->

기존에 있던 내비게이션 델리게이션의 경우, 기본적으로 첫 내비게이션 스택에서 팝 제스처를 허용하지 않기에 제거했습니다.

서브클래싱은 베이스의 순서에 따라서 뷰를 구성하면 됩니다.

예시) 뷰 컨트롤러
```swift
final class RetrospectChatViewController: BaseKeyBoardViewController {
    ...
    
    // MARK: ViewController lifecycle
    
    override func loadView() {
        view = chatView
    }
    
    override func viewDidLoad() {
        super.viewDidLoad()
        
        addTapGestureOfDismissingKeyboard()
        fetchPreviousChat(isInitial: true)
    }
    
    // MARK: RetsTalk lifecycle
    
    override func setupDelegation() {
        super.setupDelegation()
        
        chatView.setTableViewDelegate(self)
        chatView.delegate = self
    }

    override func setupNavigationBar() {
        super.setupNavigationBar()
        
        title = retrospect.createdAt.formattedToKoreanStyle
        navigationItem.rightBarButtonItem = UIBarButtonItem(
            title: Texts.endChattingButtonTitle,
            style: .plain,
            target: self,
            action: #selector(endChattingButtonTapped)
        )
    }
    
    override func setupSubscription(on subscriptionSet: inout Set<AnyCancellable>) {
        super.setupSubscription(on: &subscriptionSet)
        
        renderingSubject
            .sink(receiveValue: { [weak self] (retrospect, scrollToBottomNeeded) in
                self?.updateDataSourceDifference(from: self?.previousRetrospect?.chat ?? [], to: retrospect.chat)
                self?.previousRetrospect = retrospect
                if scrollToBottomNeeded {
                    self?.chatView.scrollToBottom()
                }
            })
            .store(in: &subscriptionSet)
    }
    
    // MARK: Keyboard control
    
    override func handleKeyboardWillShowEvent(using keyboardInfo: KeyboardInfo) {
        super.handleKeyboardWillShowEvent(using: keyboardInfo)
        
        chatView.updateLayoutForKeyboard(using: keyboardInfo)
    }
    
    override func handleKeyboardWillHideEvent(using keyboardInfo: KeyboardInfo) {
        super.handleKeyboardWillHideEvent(using: keyboardInfo)
        
        chatView.updateLayoutForKeyboard(using: keyboardInfo)
    }
}
```

예시) 뷰
```swift
final class ChatView: BaseView {

    // MARK: RetsTalk lifecycle
    
    override func setupStyles() {
        super.setupStyles()
        
        backgroundColor = .backgroundMain
    }
    
    override func setupSubviews() {
        super.setupSubviews()
        
        addSubview(messageInputView)
        messageInputView.translatesAutoresizingMaskIntoConstraints = false
        messageInputView.delegate = self
        
        addSubview(chattingTableView)
        chattingTableView.translatesAutoresizingMaskIntoConstraints = false
        chattingTableView.scrollsToTop = false
        chattingTableView.separatorStyle = .none
        chattingTableView.backgroundColor = .backgroundMain
        chattingTableView.allowsSelection = false
        chattingTableView.register(UITableViewCell.self, forCellReuseIdentifier: "MessageCell")
    }
    
    override func setupSubviewLayouts() {
        super.setupSubviewLayouts()
        
        NSLayoutConstraint.activate([
            messageInputViewHeightConstraint,
            chatViewBottomConstraint,
            messageInputView.leftAnchor.constraint(equalTo: leftAnchor),
            messageInputView.rightAnchor.constraint(equalTo: rightAnchor),
        ])
        
        NSLayoutConstraint.activate([
            chattingTableView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
            chattingTableView.bottomAnchor.constraint(equalTo: messageInputView.topAnchor),
            chattingTableView.leftAnchor.constraint(equalTo: leftAnchor),
            chattingTableView.rightAnchor.constraint(equalTo: rightAnchor),
        ])
    }
}
```

## ⌛ 소요 시간

2h