### PR TITLE
회고목록화면: 스크롤링을 통한 이전 회고 불러오기

### DIFF
--- a/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
@@ -141,10 +141,11 @@ extension Retrospect: EntityRepresentable {
 // MARK: - Retrospect kind
 
 extension Retrospect {
-    enum Kind {
+    enum Kind: Hashable {
         case pinned
         case inProgress
         case finished
+        case previous(_ lastRetrospectCreatedDate: Date)
         
         func predicate(for userID: UUID) -> CustomPredicate {
             switch self {
@@ -160,6 +161,11 @@ extension Retrospect {
                     format: "userID = %@ AND status = %@ AND isPinned = %@",
                     argumentArray: [userID, Texts.retrospectFinished, false]
                 )
+            case .previous(let lastRetrospectCreatedDate):
+                CustomPredicate(
+                    format: "userID = %@ AND status = %@ AND isPinned = %@ AND createdAt < %@",
+                    argumentArray: [userID, Texts.retrospectFinished, false, lastRetrospectCreatedDate]
+                )
             }
         }
         
@@ -167,7 +173,7 @@ extension Retrospect {
             switch self {
             case .pinned, .inProgress:
                 2
-            case .finished:
+            case .finished, .previous:
                 30
             }
         }

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManageable.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManageable.swift
@@ -13,6 +13,7 @@ protocol RetrospectManageable: Sendable {
     func createRetrospect() async -> RetrospectChatManageable?
     func retrospectChatManager(of retrospect: Retrospect) -> RetrospectChatManageable?
     func fetchRetrospects(of kindSet: Set<Retrospect.Kind>) async
+    func fetchPreviousRetrospects() async
     func togglePinRetrospect(_ retrospect: Retrospect) async
     func finishRetrospect(_ retrospect: Retrospect) async
     func deleteRetrospect(_ retrospect: Retrospect) async

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -83,6 +83,17 @@ final class RetrospectManager: RetrospectManageable {
         }
     }
     
+    func fetchPreviousRetrospects() async {
+        do {
+            let request = previousRetrospectFetchRequest(amount: Numerics.retrospectFetchAmount)
+            let fetchedRetrospects = try await retrospectStorage.fetch(by: request)
+            retrospects.append(contentsOf: fetchedRetrospects)
+            errorOccurred = nil
+        } catch {
+            errorOccurred = error
+        }
+    }
+    
     func togglePinRetrospect(_ retrospect: Retrospect) {
         do {
             guard retrospect.isPinned || isPinAvailable else { throw Error.reachInProgressLimit }
@@ -156,6 +167,21 @@ final class RetrospectManager: RetrospectManageable {
         )
     }
     
+    private func previousRetrospectFetchRequest(amount: Int) -> PersistFetchRequest<Retrospect> {
+        let recentDateSorting = CustomSortDescriptor(key: Texts.retrospectSortKey, ascending: false)
+        let lastRetrospectCreatedDate = retrospects.last?.createdAt ?? Date()
+        let predicate = CustomPredicate(
+            format: Texts.fetchPredicateFormat,
+            argumentArray: [userID, Texts.retrospectFinished, false, lastRetrospectCreatedDate]
+        )
+        let request = PersistFetchRequest<Retrospect>(
+            predicate: predicate,
+            sortDescriptors: [recentDateSorting],
+            fetchLimit: Retrospect.Kind.finished.fetchLimit
+        )
+        return request
+    }
+    
     // MARK: Manage retrospects
     
     private var isCreationAvailable: Bool {
@@ -220,5 +246,12 @@ fileprivate extension RetrospectManager {
     enum Numerics {
         static let pinLimit = 2
         static let inProgressLimit = 2
+        static let retrospectFetchAmount = 2
+    }
+    
+    enum Texts {
+        static let retrospectFinished = "retrospectFinished"
+        static let fetchPredicateFormat = "userID = %@ AND status = %@ AND isPinned = %@ AND createdAt < %@"
+        static let retrospectSortKey = "createdAt"
     }
 }

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -182,14 +182,11 @@ final class RetrospectManager: RetrospectManageable {
     private func previousRetrospectFetchRequest(amount: Int) -> PersistFetchRequest<Retrospect> {
         let recentDateSorting = CustomSortDescriptor(key: Texts.retrospectSortKey, ascending: false)
         let lastRetrospectCreatedDate = retrospects.last?.createdAt ?? Date()
-        let predicate = CustomPredicate(
-            format: Texts.fetchPredicateFormat,
-            argumentArray: [userID, Texts.retrospectFinished, false, lastRetrospectCreatedDate]
-        )
+        let predicate = Retrospect.Kind.predicate(.previous(lastRetrospectCreatedDate))(for: userID)
         let request = PersistFetchRequest<Retrospect>(
             predicate: predicate,
             sortDescriptors: [recentDateSorting],
-            fetchLimit: Retrospect.Kind.finished.fetchLimit
+            fetchLimit: Retrospect.Kind.previous(lastRetrospectCreatedDate).fetchLimit
         )
         return request
     }
@@ -264,7 +261,6 @@ fileprivate extension RetrospectManager {
     
     enum Texts {
         static let retrospectFinished = "retrospectFinished"
-        static let fetchPredicateFormat = "userID = %@ AND status = %@ AND isPinned = %@ AND createdAt < %@"
         static let retrospectSortKey = "createdAt"
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #196 

## ✨ 세부 내용
- 마지막회고를 기준으로 이전의 회고를 가져오는 기능
- 스크롤뷰의 contentOffset을 기준으로 이전 회고를 가져와 테이블 업데이트

## ✍️ 고민한 내용
매니저가 관리하는 회고 배열에는 고정됨/진행중 항목과 같이 시간순과는 관계없는 데이터가 존재합니다.
따라서 과거의 끝난 회고를 불러올 때, 현재 회고 배열의 마지막 요소를 기준으로 과거만 필터링하는 predicate을 이용했습니다.
## ⌛ 소요 시간
2H