### PR TITLE
회고목록화면: 진행 중인 회고에 대해 마지막 메세지를 셀에 보여주는 기능

### DIFF
--- a/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectListViewController.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectListViewController.swift
@@ -245,7 +245,7 @@ private extension RetrospectListViewController {
             cell.backgroundColor = .clear
             cell.contentConfiguration = UIHostingConfiguration {
                 RetrospectCell(
-                    summary: retrospect.summary ?? Texts.defaultSummaryText,
+                    summary: (retrospect.summary ?? retrospect.chat.last?.content) ?? Texts.defaultSummaryText,
                     createdAt: retrospect.createdAt,
                     isPinned: retrospect.isPinned
                 )

--- a/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
@@ -46,7 +46,7 @@ struct Retrospect {
 // MARK: - Retrospect State
 
 extension Retrospect {
-    enum Status: Equatable {
+    enum Status: Hashable {
         case finished
         case inProgress(ProgressState)
     }
@@ -63,10 +63,18 @@ extension Retrospect {
 extension Retrospect: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
+        hasher.combine(chat)
+        hasher.combine(status)
+        hasher.combine(summary)
+        hasher.combine(isPinned)
     }
     
     static func == (lhs: Retrospect, rhs: Retrospect) -> Bool {
         lhs.id == rhs.id
+        && lhs.chat == rhs.chat
+        && lhs.status == rhs.status
+        && lhs.summary == rhs.summary
+        && lhs.isPinned == rhs.isPinned
     }
 }
 

--- a/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
@@ -63,7 +63,7 @@ extension Retrospect {
 extension Retrospect: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
-        hasher.combine(chat)
+        hasher.combine(chat.last)
         hasher.combine(status)
         hasher.combine(summary)
         hasher.combine(isPinned)
@@ -71,7 +71,7 @@ extension Retrospect: Hashable {
     
     static func == (lhs: Retrospect, rhs: Retrospect) -> Bool {
         lhs.id == rhs.id
-        && lhs.chat == rhs.chat
+        && lhs.chat.last == rhs.chat.last
         && lhs.status == rhs.status
         && lhs.summary == rhs.summary
         && lhs.isPinned == rhs.isPinned


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #204 

## ✨ 세부 내용
- 마지막 메시지 변경 시 셀을 재렌더링하기 위해,  Retrospect 모델에 hash(into:) 메서드와 Equatable 조건을 추가하여 변경 사항을 감지하도록 구현했습니다.

## ✍️ 고민한 내용

<!-- 해당 PR중 고민한 내용이 있으면 적어주세요. -->

## ⌛ 소요 시간
1H  미만