### PR TITLE
회고목록화면: 이달의 회고 수 기능

### DIFF
--- a/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectListViewController.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectListViewController.swift
@@ -163,7 +163,7 @@ final class RetrospectListViewController: BaseViewController {
     
     private func updateTotalRetrospectCount() {
         Task {
-            guard let fetchedCount = await retrospectManager.fetchRetrospectsCount() else { return }
+            guard let fetchedRetrospectsCount = await retrospectManager.fetchRetrospectsCount() else { return }
             
             retrospectListView.updateHeaderContent(
                 totalCount: fetchedCount.totalCount,

--- a/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectListViewController.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectListViewController.swift
@@ -163,9 +163,12 @@ final class RetrospectListViewController: BaseViewController {
     
     private func updateTotalRetrospectCount() {
         Task {
-            guard let count = await retrospectManager.fetchRetrospectsCount() else { return }
+            guard let fetchedCount = await retrospectManager.fetchRetrospectsCount() else { return }
             
-            retrospectListView.updateButtonSubtitle(count)
+            retrospectListView.updateHeaderContent(
+                totalCount: fetchedCount.totalCount,
+                monthlyCount: fetchedCount.monthlyCount
+            )
         }
     }
 

--- a/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
@@ -146,6 +146,7 @@ extension Retrospect {
         case inProgress
         case finished
         case previous(_ lastRetrospectCreatedDate: Date)
+        case monthly(from: Date, to: Date)
         
         func predicate(for userID: UUID) -> CustomPredicate {
             switch self {
@@ -166,6 +167,11 @@ extension Retrospect {
                     format: "userID = %@ AND status = %@ AND isPinned = %@ AND createdAt < %@",
                     argumentArray: [userID, Texts.retrospectFinished, false, lastRetrospectCreatedDate]
                 )
+            case .monthly(let startOfMonth, let startOfNextMonth):
+                CustomPredicate(
+                    format: "userID == %@ AND createdAt >= %@ AND createdAt < %@",
+                    argumentArray: [userID, startOfMonth, startOfNextMonth]
+                )
             }
         }
         
@@ -175,6 +181,8 @@ extension Retrospect {
                 2
             case .finished, .previous:
                 30
+            case .monthly:
+                0
             }
         }
     }

--- a/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
@@ -167,10 +167,10 @@ extension Retrospect {
                     format: "userID = %@ AND status = %@ AND isPinned = %@ AND createdAt < %@",
                     argumentArray: [userID, Texts.retrospectFinished, false, lastRetrospectCreatedDate]
                 )
-            case .monthly(let startOfMonth, let startOfNextMonth):
+            case .monthly(let currentMonth, let nextMonth):
                 CustomPredicate(
                     format: "userID == %@ AND createdAt >= %@ AND createdAt < %@",
-                    argumentArray: [userID, startOfMonth, startOfNextMonth]
+                    argumentArray: [userID, currentMonth, nextMonth]
                 )
             }
         }

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManageable.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManageable.swift
@@ -14,7 +14,7 @@ protocol RetrospectManageable: Sendable {
     func retrospectChatManager(of retrospect: Retrospect) -> RetrospectChatManageable?
     func fetchRetrospects(of kindSet: Set<Retrospect.Kind>) async
     func fetchPreviousRetrospects() async
-    func fetchRetrospectsCount() async -> Int?
+    func fetchRetrospectsCount() async -> (totalCount: Int, monthlyCount: Int)?
     func togglePinRetrospect(_ retrospect: Retrospect) async
     func finishRetrospect(_ retrospect: Retrospect) async
     func deleteRetrospect(_ retrospect: Retrospect) async

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -196,16 +196,16 @@ final class RetrospectManager: RetrospectManageable {
     
     private func monthlyRetrospectCountFetchRequest() -> PersistFetchRequest<Retrospect> {
         let calendar = Calendar.current
-        guard let startOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: Date())),
-              let startOfNextMonth = calendar.date(byAdding: DateComponents(month: 1), to: startOfMonth)
+        guard let currentMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: Date())),
+              let nextMonth = calendar.date(byAdding: DateComponents(month: 1), to: currentMonth)
         else {
             return PersistFetchRequest<Retrospect>(fetchLimit: 0)
         }
         
-        let predicate = Retrospect.Kind.predicate(.monthly(from: startOfMonth, to: startOfNextMonth))(for: userID)
+        let predicate = Retrospect.Kind.predicate(.monthly(from: currentMonth, to: nextMonth))(for: userID)
         return PersistFetchRequest(
             predicate: predicate,
-            fetchLimit: Retrospect.Kind.monthly(from: startOfMonth, to: startOfNextMonth).fetchLimit
+            fetchLimit: Retrospect.Kind.monthly(from: currentMonth, to: nextMonth).fetchLimit
         )
     }
     

--- a/RetsTalk/RetsTalk/Retrospect/View/RetrospectListView.swift
+++ b/RetsTalk/RetsTalk/Retrospect/View/RetrospectListView.swift
@@ -146,8 +146,9 @@ final class RetrospectListView: UIView {
         calendarButton.addAction(action, for: .touchUpInside)
     }
     
-    func updateButtonSubtitle(_ totalRetrospectCount: Int) {
-        totalCountView.setSubtitle("\(totalRetrospectCount)개")
+    func updateHeaderContent(totalCount: Int, monthlyCount: Int) {
+        totalCountView.setSubtitle("\(totalCount)개")
+        calendarButton.setSubtitle("\(monthlyCount)개")
     }
 
 }
@@ -167,7 +168,7 @@ private extension RetrospectListView {
         static let foregroundImageName = "plus"
         
         static let calendarButtonImageName = "calendar"
-        static let calendarButtonTitle = "회고 쓴 일수"
+        static let calendarButtonTitle = "이달의 회고"
         
         static let totalCountButtonImageName = "tray.full.fill"
         static let totalCountButtonTitle = "총 회고 수"


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #192 

## ✨ 세부 내용

회고한 일수 대신 이달의 회고 개수를 볼 수 있는 버튼으로 수정하였습니다.
fetch요청 시점의 Date를 기준으로 한 달간 작성한 회고를 가져오는 predicate을 이용합니다.

## ✍️ 고민한 내용

<!-- 해당 PR중 고민한 내용이 있으면 적어주세요. -->

## ⌛ 소요 시간
2H 미만