### PR TITLE
이전 회고 불러오기: 요청 오류 해결

### DIFF
--- a/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectListViewController.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectListViewController.swift
@@ -23,8 +23,8 @@ final class RetrospectListViewController: BaseViewController {
     private let errorSubject: CurrentValueSubject<Error?, Never>
     
     private var dataSource: RetrospectDataSource?
-    private var isRetrospectFetching = false
-    private var isRetrospectAppendable = false
+    private var isRetrospectFetching: Bool
+    private var isRetrospectAppendable: Bool
     
     // MARK: UI Components
     
@@ -44,6 +44,9 @@ final class RetrospectListViewController: BaseViewController {
         retrospectsSubject = CurrentValueSubject(SortedRetrospects())
         errorSubject = CurrentValueSubject(nil)
         
+        isRetrospectFetching = false
+        isRetrospectAppendable = false
+        
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -62,6 +65,9 @@ final class RetrospectListViewController: BaseViewController {
         retrospectsSubject = CurrentValueSubject(SortedRetrospects())
         errorSubject = CurrentValueSubject(nil)
 
+        isRetrospectFetching = false
+        isRetrospectAppendable = false
+        
         super.init(coder: coder)
     }
     
@@ -175,15 +181,14 @@ final class RetrospectListViewController: BaseViewController {
     private func fetchPreviousRetrospects() {
         Task {
             let appendedCount = await retrospectManager.fetchPreviousRetrospects()
+            isRetrospectFetching = false
             guard appendedCount != 0
             else {
                 isRetrospectAppendable = false
-                isRetrospectFetching = false
                 return
             }
             
             sortAndSendRetrospects()
-            isRetrospectFetching = false
         }
     }
     
@@ -290,7 +295,8 @@ extension RetrospectListViewController: UITableViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let offsetY = scrollView.contentOffset.y
         let contentHeight = scrollView.contentSize.height
-        guard offsetY > contentHeight - scrollView.frame.height - Metrics.fetchingOffsetThreshold,
+        let isNearBottom = offsetY > contentHeight - scrollView.frame.height - Metrics.fetchingOffsetThreshold
+        guard isNearBottom,
               !isRetrospectFetching,
               isRetrospectAppendable
         else { return }

--- a/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
@@ -72,7 +72,7 @@ extension Retrospect: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
         hasher.combine(userID)
-        hasher.combine(chat.last)
+        hasher.combine(chat.count)
         hasher.combine(status)
         hasher.combine(summary)
         hasher.combine(isPinned)
@@ -81,7 +81,7 @@ extension Retrospect: Hashable {
     static func == (lhs: Retrospect, rhs: Retrospect) -> Bool {
         lhs.id == rhs.id
         && lhs.userID == rhs.userID
-        && lhs.chat.last == rhs.chat.last
+        && lhs.chat.count == rhs.chat.count
         && lhs.status == rhs.status
         && lhs.summary == rhs.summary
         && lhs.isPinned == rhs.isPinned

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManageable.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManageable.swift
@@ -13,7 +13,7 @@ protocol RetrospectManageable: Sendable {
     func createRetrospect() -> RetrospectChatManageable?
     func retrospectChatManager(of retrospect: Retrospect) -> RetrospectChatManageable?
 
-    func fetchRetrospects(of kindSet: [Retrospect.Kind])
+    func fetchRetrospects(of kindList: [Retrospect.Kind])
     func fetchPreviousRetrospects() -> Int
     func fetchRetrospectsCount() -> Int?
     func togglePinRetrospect(_ retrospect: Retrospect)

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManageable.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManageable.swift
@@ -13,8 +13,8 @@ protocol RetrospectManageable: Sendable {
     func createRetrospect() -> RetrospectChatManageable?
     func retrospectChatManager(of retrospect: Retrospect) -> RetrospectChatManageable?
 
-    func fetchRetrospects(of kindSet: Set<Retrospect.Kind>)
-    func fetchPreviousRetrospects()
+    func fetchRetrospects(of kindSet: [Retrospect.Kind])
+    func fetchPreviousRetrospects() -> Int
     func fetchRetrospectsCount() -> Int?
     func togglePinRetrospect(_ retrospect: Retrospect)
     func finishRetrospect(_ retrospect: Retrospect) async

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -68,9 +68,9 @@ final class RetrospectManager: RetrospectManageable {
         return retrospectChatManager
     }
     
-    func fetchRetrospects(of kindSet: [Retrospect.Kind]) {
+    func fetchRetrospects(of kindList: [Retrospect.Kind]) {
         do {
-            for kind in kindSet {
+            for kind in kindList {
                 let request = retrospectFetchRequest(for: kind)
                 let fetchedRetrospects = try retrospectStorage.fetch(by: request)
                 for retrospect in fetchedRetrospects where !retrospects.contains(retrospect) {

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -68,7 +68,7 @@ final class RetrospectManager: RetrospectManageable {
         return retrospectChatManager
     }
     
-    func fetchRetrospects(of kindSet: Set<Retrospect.Kind>) {
+    func fetchRetrospects(of kindSet: [Retrospect.Kind]) {
         do {
             for kind in kindSet {
                 let request = retrospectFetchRequest(for: kind)
@@ -83,14 +83,16 @@ final class RetrospectManager: RetrospectManageable {
         }
     }
     
-    func fetchPreviousRetrospects() {
+    func fetchPreviousRetrospects() -> Int {
         do {
             let request = previousRetrospectFetchRequest(amount: Numerics.retrospectFetchAmount)
             let fetchedRetrospects = try retrospectStorage.fetch(by: request)
             retrospects.append(contentsOf: fetchedRetrospects)
             errorOccurred = nil
+            return fetchedRetrospects.count
         } catch {
             errorOccurred = error
+            return 0
         }
     }
     

--- a/RetsTalk/RetsTalk/Retrospect/View/RetrospectListView.swift
+++ b/RetsTalk/RetsTalk/Retrospect/View/RetrospectListView.swift
@@ -15,6 +15,7 @@ final class RetrospectListView: UIView {
         let tableView = UITableView()
         tableView.separatorStyle = .none
         tableView.backgroundColor = .backgroundMain
+        tableView.contentInset.bottom = Metrics.tableViewBottonPadding
         tableView.rowHeight = UITableView.automaticDimension
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: Constants.Texts.retrospectCellIdentifier)
         return tableView
@@ -156,6 +157,7 @@ final class RetrospectListView: UIView {
 
 private extension RetrospectListView {
     enum Metrics {
+        static let tableViewBottonPadding = 60.0
         static let diameter = 80.0
         static let buttonBottomAnchorConstant = -10.0
         static let fixedButtonAreaHeight = 40.0


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #211 

## ✨ 세부 내용
 - 스크롤링 페치 로직 수정
 - 과거의 회고 fetch함수 로직 수정
 - 스크롤링을 통한 페치요청 디바운스

## ✍️ 고민한 내용

## 1
### 문제 상황
목록화면 진입 시, **스냅샷 업데이트가 굉장히 많이 발생**하는 오류가 있었습니다.
특히 회고 수가 적은 상황에서 스크롤링이 조금만 발생해도 페치 요청이 터지듯(중복적으로) 발생합니다.
그리고 새로운 데이터를 가져올 때, 중복된 요청이나 더이상 가져올 데이터가 없는 상황에도 계속해서 요청이 발생했습니다.

### 해결 과정
목록화면 진입 시 
1. viewDidLoad의 `initialFetch()`에 대한 스냅샷 업데이트
2. ViewDidLoad의 currentValueSubject 구독에 의한 스냅샷 업데이트
3. ViewWillAppear의 스냅샷 업데이트

와 같이 이벤트가 발생했고, 이 중 2번의 업데이트는 불필요하다고 판단하여 구독 시 dropFirst() 메서드를 통해 무시하도록 처리했습니다.

또한, 
1. debounce를 처리하는 PassthroughSubject를 두어 0.5초 간격을 제공해 중복요청을 방지했으며,
2. `isRetrospectAppendable` 플래그를 이용해  과거데이터 요청 시, 반환 결과의 개수가 0일 시 더 요청을 못하도록 막았습니다.

## 2
### 문제 상황
앱 실행 시, 1/3 확률로 랜덤하게 스냅샷 업데이트 오류로 인해 앱 크래시가 발생했습니다.

기존에는 `inifialFetch()` 메서드를 통해 최초페치를 실행할 때 매개변수로 Set<Kind>를 전달받으므로 순서(`isPinned`, `inProgress`, `finished`)에 관계없는 페치가 진행되었습니다. 

그러나 **스크롤링으로 새로운 데이터를 페치해오는 경우**, 기존 회고배열 마지막요소의 `createdAt`을 기준으로 가져옵니다. 이때 마지막 요소가 finished가 아닌 pinned나 inprogress에 속할 경우 그 시간을 기준으로 과거의 것을 중복체크하지 않고 가져오므로, **고유 값이 같은 데이터 중복으로 인한 스냅샷 해시충돌**로 인한 앱크래시가 발생했습니다.

### 해결 과정
따라서 Set이 아닌 List로 Kind를 전달하도록 변경하였습니다.

## ⌛ 소요 시간
2H