### PR TITLE
회고 도움 요청 표시 및 재시도 기능 추가(#93)

### DIFF
--- a/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
@@ -59,6 +59,7 @@ final class RetrospectChatManager: RetrospectChatManageable {
             let userMessage = Message(retrospectID: retrospect.id, role: .user, content: content)
             let addedUserMessage = try messageStorage.add(contentsOf: [userMessage])
             retrospect.append(contentsOf: addedUserMessage)
+            retrospect.summary = addedUserMessage.last?.content
         } catch {
             errorSubject.send(error)
         }
@@ -69,10 +70,12 @@ final class RetrospectChatManager: RetrospectChatManageable {
     
     func requestAssistantMessage() async {
         do {
+            retrospect.status = .inProgress(.waitingForResponse)
             let assistantMessage = try await assistantMessageProvider.requestAssistantMessage(for: retrospect)
             let addedAssistantMessage = try messageStorage.add(contentsOf: [assistantMessage])
             retrospect.append(contentsOf: addedAssistantMessage)
             retrospect.status = .inProgress(.waitingForUserInput)
+            retrospect.summary = addedAssistantMessage.last?.content
         } catch {
             retrospect.status = .inProgress(.responseErrorOccurred)
             errorSubject.send(error)

--- a/RetsTalk/RetsTalk/Chat/View/ChatView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/ChatView.swift
@@ -9,7 +9,8 @@ import UIKit
 
 @MainActor
 protocol ChatViewDelegate: AnyObject {
-    func sendMessage(_ chatView: ChatView, with text: String)
+    func willSendMessage(from chatView: ChatView, with content: String)
+    func didTapRetryButton(_ retryButton: UIButton)
 }
 
 final class ChatView: BaseView {
@@ -25,6 +26,17 @@ final class ChatView: BaseView {
         tableView.allowsSelection = false
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: Texts.messageCellIdentifier)
         return tableView
+    }()
+    private let activityIndicatorView: UIActivityIndicatorView = {
+        let activityIndicatorView = UIActivityIndicatorView(style: .medium)
+        activityIndicatorView.color = .blazingOrange
+        activityIndicatorView.translatesAutoresizingMaskIntoConstraints = false
+        return activityIndicatorView
+    }()
+    private let retryView: RetryView = {
+        let retryView = RetryView()
+        retryView.isHidden = true
+        return retryView
     }()
     private let messageInputView = MessageInputView()
     
@@ -44,8 +56,10 @@ final class ChatView: BaseView {
     override func setupSubviews() {
         super.setupSubviews()
         
-        addSubview(messageInputView)
         addSubview(chatTableView)
+        addSubview(activityIndicatorView)
+        addSubview(retryView)
+        addSubview(messageInputView)
         
         messageInputView.delegate = self
     }
@@ -54,7 +68,19 @@ final class ChatView: BaseView {
         super.setupSubviewLayouts()
         
         setupChatTableViewLayouts()
+        setupActivityIndicatorViewLayouts()
+        setupRetryViewLayouts()
         setupMessageInputViewLayouts()
+    }
+    
+    override func setupActions() {
+        super.setupActions()
+        
+        retryView.addAction { [weak self] in
+            guard let self else { return }
+            
+            self.delegate?.didTapRetryButton(self.retryView.retryButton)
+        }
     }
     
     // MARK: Delegation
@@ -76,11 +102,7 @@ final class ChatView: BaseView {
         guard 0 < rows else { return }
         
         let indexPath = IndexPath(row: rows - 1, section: 0)
-        chatTableView.scrollToRow(
-            at: indexPath,
-            at: .bottom,
-            animated: false
-        )
+        chatTableView.scrollToRow(at: indexPath, at: .bottom, animated: false)
     }
     
     func insertMessages(at indexPaths: [IndexPath]) {
@@ -99,24 +121,50 @@ final class ChatView: BaseView {
         }
     }
     
-    // MARK: Input state handling
+    // MARK: Retrospect Status handling
     
-    func updateRequestInProgressState(_ state: Bool) {
-        messageInputView.updateRequestInProgressState(state)
+    func updateChatView(by status: Retrospect.Status) {
+        switch status {
+        case .finished:
+            messageInputView.isHidden = true
+        case .inProgress(.waitingForUserInput):
+            setViewAsWaitingForUserInput()
+        case .inProgress(.waitingForResponse):
+            setViewAsWaitingForResponse()
+        case .inProgress(.responseErrorOccurred):
+            setViewAsResponseErrorOccurred()
+        }
+    }
+    
+    private func setViewAsWaitingForUserInput() {
+        activityIndicatorView.stopAnimating()
+        messageInputView.updateRequestInProgressState(false)
+    }
+    
+    private func setViewAsWaitingForResponse() {
+        retryView.isHidden = true
+        activityIndicatorView.startAnimating()
+        messageInputView.updateRequestInProgressState(true)
+    }
+    
+    private func setViewAsResponseErrorOccurred() {
+        activityIndicatorView.stopAnimating()
+        retryView.isHidden = false
+        messageInputView.updateRequestInProgressState(true)
     }
 }
 
 // MARK: - MessageInputViewDelegate
 
 extension ChatView: MessageInputViewDelegate {
-    func sendMessage(_ messageInputView: MessageInputView, with text: String) {
-        delegate?.sendMessage(self, with: text)
+    func willSendMessage(_ messageInputView: MessageInputView, with content: String) {
+        delegate?.willSendMessage(from: self, with: content)
     }
     
     func updateMessageInputViewHeight(_ messageInputView: MessageInputView, to height: CGFloat) {
         messageInputViewHeightConstraint?.constant = height
         UIView.performWithoutAnimation {
-            self.layoutIfNeeded()
+            layoutIfNeeded()
         }
     }
 }
@@ -128,8 +176,8 @@ fileprivate extension ChatView {
         NSLayoutConstraint.activate([
             chatTableView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
             chatTableView.bottomAnchor.constraint(equalTo: messageInputView.topAnchor),
-            chatTableView.leftAnchor.constraint(equalTo: leftAnchor),
-            chatTableView.rightAnchor.constraint(equalTo: rightAnchor),
+            chatTableView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+            chatTableView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
         ])
     }
     
@@ -143,12 +191,42 @@ fileprivate extension ChatView {
         NSLayoutConstraint.activate([
             messageInputViewHeightConstraint,
             messageInputViewBottomConstraint,
-            messageInputView.leftAnchor.constraint(equalTo: leftAnchor),
-            messageInputView.rightAnchor.constraint(equalTo: rightAnchor),
+            messageInputView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+            messageInputView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
         ])
         
         self.messageInputViewHeightConstraint = messageInputViewHeightConstraint
         chatViewBottomConstraint = messageInputViewBottomConstraint
+    }
+    
+    func setupActivityIndicatorViewLayouts() {
+        NSLayoutConstraint.activate([
+            activityIndicatorView.bottomAnchor.constraint(
+                equalTo: messageInputView.topAnchor,
+                constant: -Metrics.defaultPadding
+            ),
+            activityIndicatorView.leadingAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.leadingAnchor,
+                constant: Metrics.defaultPadding
+            ),
+        ])
+    }
+    
+    func setupRetryViewLayouts() {
+        NSLayoutConstraint.activate([
+            retryView.bottomAnchor.constraint(
+                equalTo: messageInputView.topAnchor,
+                constant: -Metrics.defaultPadding
+            ),
+            retryView.leadingAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.leadingAnchor,
+                constant: Metrics.defaultPadding
+            ),
+            retryView.trailingAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.trailingAnchor,
+                constant: -Metrics.defaultPadding
+            ),
+        ])
     }
 }
 
@@ -158,6 +236,7 @@ private extension ChatView {
     enum Metrics {
         static let messageInputViewHeight = 54.0
         static let chatViewBottomFromBottom = -40.0
+        static let defaultPadding = 16.0
     }
     
     enum Texts {

--- a/RetsTalk/RetsTalk/Chat/View/ChatView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/ChatView.swift
@@ -19,7 +19,6 @@ final class ChatView: BaseView {
     
     private let chatTableView: UITableView = {
         let tableView = UITableView()
-        tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.scrollsToTop = false
         tableView.separatorStyle = .none
         tableView.backgroundColor = .backgroundMain
@@ -30,7 +29,6 @@ final class ChatView: BaseView {
     private let activityIndicatorView: UIActivityIndicatorView = {
         let activityIndicatorView = UIActivityIndicatorView(style: .medium)
         activityIndicatorView.color = .blazingOrange
-        activityIndicatorView.translatesAutoresizingMaskIntoConstraints = false
         return activityIndicatorView
     }()
     private let retryView: RetryView = {
@@ -173,6 +171,8 @@ extension ChatView: MessageInputViewDelegate {
 
 fileprivate extension ChatView {
     func setupChatTableViewLayouts() {
+        chatTableView.translatesAutoresizingMaskIntoConstraints = false
+        
         NSLayoutConstraint.activate([
             chatTableView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
             chatTableView.bottomAnchor.constraint(equalTo: messageInputView.topAnchor),
@@ -182,6 +182,8 @@ fileprivate extension ChatView {
     }
     
     func setupMessageInputViewLayouts() {
+        messageInputView.translatesAutoresizingMaskIntoConstraints = false
+        
         let messageInputViewHeightConstraint = messageInputView.heightAnchor.constraint(
             equalToConstant: Metrics.messageInputViewHeight
         )
@@ -200,6 +202,8 @@ fileprivate extension ChatView {
     }
     
     func setupActivityIndicatorViewLayouts() {
+        activityIndicatorView.translatesAutoresizingMaskIntoConstraints = false
+        
         NSLayoutConstraint.activate([
             activityIndicatorView.bottomAnchor.constraint(
                 equalTo: messageInputView.topAnchor,
@@ -213,6 +217,8 @@ fileprivate extension ChatView {
     }
     
     func setupRetryViewLayouts() {
+        retryView.translatesAutoresizingMaskIntoConstraints = false
+        
         NSLayoutConstraint.activate([
             retryView.bottomAnchor.constraint(
                 equalTo: messageInputView.topAnchor,

--- a/RetsTalk/RetsTalk/Chat/View/MessageInputView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/MessageInputView.swift
@@ -25,7 +25,6 @@ final class MessageInputView: BaseView {
         let view = UIView()
         view.backgroundColor = .systemGray6
         view.layer.cornerRadius = Metrics.backgroundCornerRadius
-        view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
     private var textInputView: UITextView = {
@@ -36,7 +35,6 @@ final class MessageInputView: BaseView {
         textView.backgroundColor = .clear
         textView.textContainerInset = UIEdgeInsets(top: 1, left: 0, bottom: 0, right: 0)
         textView.isScrollEnabled = false
-        textView.translatesAutoresizingMaskIntoConstraints = false
         return textView
     }()
     private var sendButton: UIButton = {
@@ -48,17 +46,10 @@ final class MessageInputView: BaseView {
         button.setImage(icon, for: .normal)
         button.tintColor = .blazingOrange
         button.isEnabled = false
-        button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
     
     // MARK: RetsTalk lifecycle
-    
-    override func setupStyles() {
-        super.setupStyles()
-        
-        translatesAutoresizingMaskIntoConstraints = false
-    }
     
     override func setupSubviews() {
         super.setupSubviews()
@@ -161,6 +152,8 @@ extension MessageInputView: UITextViewDelegate {
 
 fileprivate extension MessageInputView {
     private func setUpBackgroundViewLayout() {
+        backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        
         NSLayoutConstraint.activate([
             backgroundView.leftAnchor.constraint(
                 equalTo: leftAnchor,
@@ -181,6 +174,8 @@ fileprivate extension MessageInputView {
     }
     
     private func setUpSendButtonLayout() {
+        sendButton.translatesAutoresizingMaskIntoConstraints = false
+        
         NSLayoutConstraint.activate([
             sendButton.heightAnchor.constraint(
                 equalToConstant: Metrics.sendButtonSideLength
@@ -200,6 +195,8 @@ fileprivate extension MessageInputView {
     }
     
     private func setUpTextInputViewLayout() {
+        textInputView.translatesAutoresizingMaskIntoConstraints = false
+        
         NSLayoutConstraint.activate([
             textInputView.topAnchor.constraint(
                 equalTo: backgroundView.topAnchor,

--- a/RetsTalk/RetsTalk/Chat/View/MessageInputView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/MessageInputView.swift
@@ -10,7 +10,7 @@ import UIKit
 @MainActor
 protocol MessageInputViewDelegate: AnyObject {
     func updateMessageInputViewHeight(_ messageInputView: MessageInputView, to height: CGFloat)
-    func sendMessage(_ messageInputView: MessageInputView, with text: String)
+    func willSendMessage(_ messageInputView: MessageInputView, with content: String)
 }
 
 final class MessageInputView: BaseView {
@@ -28,7 +28,6 @@ final class MessageInputView: BaseView {
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
-    
     private var textInputView: UITextView = {
         let textView = UITextView()
         textView.font = .appFont(.body)
@@ -40,7 +39,6 @@ final class MessageInputView: BaseView {
         textView.translatesAutoresizingMaskIntoConstraints = false
         return textView
     }()
-    
     private var sendButton: UIButton = {
         let button = UIButton()
         let icon = UIImage(
@@ -88,7 +86,7 @@ final class MessageInputView: BaseView {
                 handler: { [weak self] _ in
                     guard let self else { return }
                     
-                    self.delegate?.sendMessage(self, with: self.textInputView.text)
+                    self.delegate?.willSendMessage(self, with: self.textInputView.text)
                     self.textInputView.text = nil
                     self.sendButton.isEnabled = false
                     self.updateRequestInProgressState(true)

--- a/RetsTalk/RetsTalk/Chat/View/RetryView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/RetryView.swift
@@ -7,84 +7,78 @@
 
 import UIKit
 
-final class RetryView: UIView {
+final class RetryView: BaseView {
     
-    // MARK: UI Components
+    // MARK: Subviews
 
     private let backgroundLabel: UILabel = {
         let label = UILabel()
         label.text = Texts.backgroundLabelText
         label.textColor = .blazingOrange
         label.font = UIFont.appFont(.body)
+        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
-    private let retryButton: UIButton = {
+    let retryButton: UIButton = {
         let button = UIButton()
         button.setTitle(Texts.buttonLabelText, for: .normal)
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = .blazingOrange
         button.layer.cornerRadius = Metrics.cornerRadius
+        button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
     
-    // MARK: init method
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        
-        configureAppearance()
-        setUpSubViewLayout()
-    }
+    // MARK: RetsTalk lifecycle
     
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
+    override func setupStyles() {
+        super.setupStyles()
         
-        configureAppearance()
-        setUpSubViewLayout()
-    }
-    
-    // MARK: custom method
-
-    private func configureAppearance() {
         backgroundColor = .backgroundRetrospect
         layer.borderWidth = Metrics.backgroundBorderWidth
         layer.borderColor = UIColor.blazingOrange.cgColor
         layer.cornerRadius = Metrics.cornerRadius
+        translatesAutoresizingMaskIntoConstraints = false
     }
     
-    private func setUpSubViewLayout() {
+    override func setupSubviews() {
+        super.setupSubviews()
+        
         addSubview(retryButton)
         addSubview(backgroundLabel)
-        
-        retryButton.translatesAutoresizingMaskIntoConstraints = false
-        backgroundLabel.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    override func setupSubviewLayouts() {
+        super.setupSubviewLayouts()
         
         NSLayoutConstraint.activate([
-            retryButton.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: Metrics.padding),
-            retryButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -Metrics.padding),
-            retryButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -Metrics.padding),
+            retryButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metrics.padding),
+            retryButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Metrics.padding),
+            retryButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Metrics.padding),
             retryButton.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight),
             
-            backgroundLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-            backgroundLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: Metrics.padding),
+            backgroundLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            backgroundLabel.topAnchor.constraint(equalTo: topAnchor, constant: Metrics.padding),
             backgroundLabel.bottomAnchor.constraint(equalTo: retryButton.topAnchor, constant: -Metrics.padding),
             
-            self.heightAnchor.constraint(equalToConstant: Metrics.retryViewHeight),
+            heightAnchor.constraint(equalToConstant: Metrics.retryViewHeight),
         ])
     }
     
+    // MARK: Setup action
+    
     func addAction(_ action: @escaping () -> Void) {
-        retryButton.addAction(UIAction(handler: { _ in
-            action()
-        }), for: .touchUpInside)
+        retryButton.addAction(
+            UIAction { _ in action() },
+            for: .touchUpInside
+        )
     }
 }
 
-private extension RetryView {
-    
-    // MARK: constants
+// MARK: - Constants
 
+private extension RetryView {
     enum Metrics {
         static let cornerRadius = 16.0
         static let backgroundBorderWidth = 0.5

--- a/RetsTalk/RetsTalk/Chat/View/RetryView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/RetryView.swift
@@ -16,7 +16,6 @@ final class RetryView: BaseView {
         label.text = Texts.backgroundLabelText
         label.textColor = .blazingOrange
         label.font = UIFont.appFont(.body)
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
@@ -26,7 +25,6 @@ final class RetryView: BaseView {
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = .blazingOrange
         button.layer.cornerRadius = Metrics.cornerRadius
-        button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
     
@@ -39,7 +37,6 @@ final class RetryView: BaseView {
         layer.borderWidth = Metrics.backgroundBorderWidth
         layer.borderColor = UIColor.blazingOrange.cgColor
         layer.cornerRadius = Metrics.cornerRadius
-        translatesAutoresizingMaskIntoConstraints = false
     }
     
     override func setupSubviews() {
@@ -51,6 +48,9 @@ final class RetryView: BaseView {
     
     override func setupSubviewLayouts() {
         super.setupSubviewLayouts()
+        
+        retryButton.translatesAutoresizingMaskIntoConstraints = false
+        backgroundLabel.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
             retryButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metrics.padding),

--- a/RetsTalk/RetsTalk/Network/NetworkRequestable.swift
+++ b/RetsTalk/RetsTalk/Network/NetworkRequestable.swift
@@ -35,6 +35,7 @@ extension NetworkRequestable {
             request.url?.append(queryItems: [URLQueryItem(name: $0.key, value: $0.value)])
         }
         request.httpBody = try urlRequestComposer.data?.encodeJSON()
+        request.timeoutInterval = 7
         return request
     }
     


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #93 

## ✨ 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

https://github.com/user-attachments/assets/a2967390-5af0-42a3-916d-254d5ce83da2

- 좌하단에 요청중 인디케이터가 뜹니다.
- 실패의 경우 재요청을 할 수 있는 화면이 뜹니다.
- 끝이 나지 않은 회고의 경우, 요약이 마지막 메시지로 들어갑니다.
- 레이아웃은 leading과 trailing을 활용하고(아랍대비 ㅎㅎ), 세이프 에어리어를 활용해서 가로스크린에 대응합니다.

## ⌛ 소요 시간

2h