### PR TITLE
회고 대화 오류/끝내기 Alert 및 고정 기능(#218)

### DIFF
--- a/RetsTalk/RetsTalk/Chat/Controller/RetrospectChatViewController.swift
+++ b/RetsTalk/RetsTalk/Chat/Controller/RetrospectChatViewController.swift
@@ -90,12 +90,7 @@ final class RetrospectChatViewController: BaseKeyBoardViewController {
         
         title = retrospect.createdAt.formattedToKoreanStyle
         navigationItem.largeTitleDisplayMode = .never
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: Texts.endChattingButtonTitle,
-            style: .plain,
-            target: self,
-            action: #selector(endRetrospectChat)
-        )
+        navigationItem.rightBarButtonItem = rightBarButtonItem(for: retrospect)
     }
     
     override func setupSubscription() {
@@ -195,6 +190,14 @@ final class RetrospectChatViewController: BaseKeyBoardViewController {
         presentAlert(for: .finish, actions: [.close(), conformAction])
     }
     
+    @objc
+    private func toggleRetrospectPin() {
+        Task {
+            await retrospectChatManager.toggleRetrospectPin()
+            navigationItem.rightBarButtonItem = rightBarButtonItem(for: retrospect)
+        }
+    }
+    
     // MARK: Keyboard control
     
     override func handleKeyboardWillShowEvent(using keyboardInfo: KeyboardInfo) {
@@ -226,6 +229,25 @@ final class RetrospectChatViewController: BaseKeyBoardViewController {
             chatView.scrollToBottom()
         }
         chatView.updateChatView(by: retrospect.status)
+    }
+    
+    private func rightBarButtonItem(for retrospect: Retrospect) -> UIBarButtonItem {
+        switch retrospect.status {
+        case .finished:
+            UIBarButtonItem(
+                title: nil,
+                image: retrospect.isPinned ? .pinned : .unpinned,
+                target: self,
+                action: #selector(toggleRetrospectPin)
+            )
+        case .inProgress:
+            UIBarButtonItem(
+                title: Texts.endChattingButtonTitle,
+                style: .plain,
+                target: self,
+                action: #selector(endRetrospectChat)
+            )
+        }
     }
 }
 

--- a/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
@@ -56,16 +56,19 @@ final class RetrospectChatManager: RetrospectChatManageable {
     
     func sendMessage(_ content: String) async {
         do {
+            guard content.count <= Numeric.messageContentCountLimit
+            else { throw Error.messageContentCountExceeded(currentCount: content.count) }
+            
             let userMessage = Message(retrospectID: retrospect.id, role: .user, content: content)
             let addedUserMessage = try messageStorage.add(contentsOf: [userMessage])
             retrospect.append(contentsOf: addedUserMessage)
             retrospect.summary = addedUserMessage.last?.content
+            
+            retrospect.status = .inProgress(.waitingForResponse)
+            await requestAssistantMessage()
         } catch {
             errorSubject.send(error)
         }
-        retrospect.status = .inProgress(.waitingForResponse)
-        
-        await requestAssistantMessage()
     }
     
     func requestAssistantMessage() async {
@@ -135,10 +138,22 @@ final class RetrospectChatManager: RetrospectChatManageable {
 
 fileprivate extension RetrospectChatManager {
     enum Error: LocalizedError {
+        case messageContentCountExceeded(currentCount: Int)
         case pinUnavailable
         
         var errorDescription: String? {
             switch self {
+            case .messageContentCountExceeded:
+                "메시지 내용 수 초과"
+            case .pinUnavailable:
+                "회고 고정 실패"
+            }
+        }
+        
+        var failureReason: String? {
+            switch self {
+            case let .messageContentCountExceeded(currentCount):
+                "현재 입력은 \(currentCount)자 입니다. 최대 100자까지 입력 가능합니다."
             case .pinUnavailable:
                 "회고를 고정할 수 없습니다.\n최대 고정 개수는 2개입니다."
             }
@@ -151,6 +166,7 @@ fileprivate extension RetrospectChatManager {
 fileprivate extension RetrospectChatManager {
     enum Numeric {
         static let messageFetchAmount = 30
+        static let messageContentCountLimit = 100
     }
     
     enum Texts {

--- a/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
+++ b/RetsTalk/RetsTalk/Chat/Model/RetrospectChatManager.swift
@@ -140,7 +140,7 @@ fileprivate extension RetrospectChatManager {
         var errorDescription: String? {
             switch self {
             case .pinUnavailable:
-                "회고를 고정할 수 없습니다. 최대 고정 개수는 2개입니다."
+                "회고를 고정할 수 없습니다.\n최대 고정 개수는 2개입니다."
             }
         }
     }

--- a/RetsTalk/RetsTalk/Chat/View/ChatView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/ChatView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 @MainActor
 protocol ChatViewDelegate: AnyObject {
-    func willSendMessage(from chatView: ChatView, with content: String)
+    func willSendMessage(from chatView: ChatView, with content: String) -> Bool
     func didTapRetryButton(_ retryButton: UIButton)
 }
 
@@ -124,6 +124,10 @@ final class ChatView: BaseView {
         }
     }
     
+    func addTapGestureToDismissKeyboard(_ gestureRecognizer: UIGestureRecognizer) {
+        chatTableView.addGestureRecognizer(gestureRecognizer)
+    }
+    
     // MARK: Retrospect Status handling
     
     func updateChatView(by status: Retrospect.Status) {
@@ -160,8 +164,8 @@ final class ChatView: BaseView {
 // MARK: - MessageInputViewDelegate
 
 extension ChatView: MessageInputViewDelegate {
-    func willSendMessage(_ messageInputView: MessageInputView, with content: String) {
-        delegate?.willSendMessage(from: self, with: content)
+    func willSendMessage(_ messageInputView: MessageInputView, with content: String) -> Bool {
+        delegate?.willSendMessage(from: self, with: content) ?? false
     }
     
     func updateMessageInputViewHeight(_ messageInputView: MessageInputView, to height: CGFloat) {

--- a/RetsTalk/RetsTalk/Chat/View/ChatView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/ChatView.swift
@@ -113,9 +113,14 @@ final class ChatView: BaseView {
     // MARK: Keyboard action
     
     func updateLayoutForKeyboard(using keyboardInfo: KeyboardInfo) {
-        chatViewBottomConstraint?.constant = min(-(keyboardInfo.frame.height - safeAreaInsets.bottom), 0)
+        let willKeyboardShow = 0 < keyboardInfo.frame.height
+        let updatedChatViewBottomConstant = -(keyboardInfo.frame.height - safeAreaInsets.bottom)
+        chatViewBottomConstraint?.constant = min(updatedChatViewBottomConstant, 0)
         UIView.animate(withDuration: keyboardInfo.animationDuration) { [self] in
             layoutIfNeeded()
+            if willKeyboardShow {
+                scrollToBottom()
+            }
         }
     }
     

--- a/RetsTalk/RetsTalk/Chat/View/MessageInputView.swift
+++ b/RetsTalk/RetsTalk/Chat/View/MessageInputView.swift
@@ -10,7 +10,7 @@ import UIKit
 @MainActor
 protocol MessageInputViewDelegate: AnyObject {
     func updateMessageInputViewHeight(_ messageInputView: MessageInputView, to height: CGFloat)
-    func willSendMessage(_ messageInputView: MessageInputView, with content: String)
+    func willSendMessage(_ messageInputView: MessageInputView, with content: String) -> Bool
 }
 
 final class MessageInputView: BaseView {
@@ -77,11 +77,13 @@ final class MessageInputView: BaseView {
                 handler: { [weak self] _ in
                     guard let self else { return }
                     
-                    self.delegate?.willSendMessage(self, with: self.textInputView.text)
-                    self.textInputView.text = nil
-                    self.sendButton.isEnabled = false
-                    self.updateRequestInProgressState(true)
-                    self.updateHeight(to: self.currentTextViewHeight(textView: textInputView))
+                    let didSend = self.delegate?.willSendMessage(self, with: self.textInputView.text)
+                    if didSend ?? false {
+                        self.textInputView.text = nil
+                        self.sendButton.isEnabled = false
+                        self.updateRequestInProgressState(true)
+                        self.updateHeight(to: self.currentTextViewHeight(textView: textInputView))
+                    }
                 }),
             for: .touchUpInside
         )
@@ -237,6 +239,6 @@ private extension MessageInputView {
 
     enum Texts {
         static let sendButtonIconName = "arrow.up.circle"
-        static let textInputPlaceholder = "메시지 입력"
+        static let textInputPlaceholder = "메시지 입력 최대 100자"
     }
 }

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -236,7 +236,7 @@ extension RetrospectManager: RetrospectChatManagerListener {
     }
     
     func shouldTogglePin(_ retrospectChatManageable: RetrospectChatManageable, retrospect: Retrospect) -> Bool {
-        isPinAvailable
+        retrospect.isPinned || isPinAvailable
     }
 }
 

--- a/RetsTalk/RetsTalk/Utility/Extensions/UIImage+Extension.swift
+++ b/RetsTalk/RetsTalk/Utility/Extensions/UIImage+Extension.swift
@@ -10,21 +10,28 @@ import UIKit
 extension UIImage {
     enum SystemImage {
         case leftChevron
+        case pinned
+        case unpinned
         
         var name: String {
             switch self {
             case .leftChevron:
-                return "chevron.left"
+                "chevron.left"
+            case .pinned:
+                "pin.fill"
+            case .unpinned:
+                "pin"
             }
         }
     }
 
     convenience init?(systemImage: SystemImage) {
-        switch systemImage {
-        case .leftChevron:
-            self.init(systemName: systemImage.name)
-        }
+        self.init(systemName: systemImage.name)
     }
+    
+    static let leftChevron = UIImage(systemImage: .leftChevron)
+    static let pinned = UIImage(systemImage: .pinned)
+    static let unpinned = UIImage(systemImage: .unpinned)
     
     /// 시스템 아이콘 이름으로 tintColor를 적용한 후 주어진 비율로 크기 조정합니다.
     static func systemImage(named name: String, tintColor: UIColor, scaleFactor: CGFloat) -> UIImage? {

--- a/RetsTalk/RetsTalk/Utility/View/AlertPresentable.swift
+++ b/RetsTalk/RetsTalk/Utility/View/AlertPresentable.swift
@@ -39,7 +39,7 @@ extension UIAlertAction {
         UIAlertAction(title: "닫기", style: .cancel, handler: handler)
     }
     
-    static func conform(handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+    static func confirm(handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
         UIAlertAction(title: "확인", style: .default, handler: handler)
     }
 }

--- a/RetsTalk/RetsTalk/Utility/View/AlertPresentable.swift
+++ b/RetsTalk/RetsTalk/Utility/View/AlertPresentable.swift
@@ -33,3 +33,13 @@ protocol AlertSituation {
     /// 알림의 내용을 담고 있는 문자열입니다.
     var message: String { get }
 }
+
+extension UIAlertAction {
+    static func close(handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+        UIAlertAction(title: "닫기", style: .cancel, handler: handler)
+    }
+    
+    static func conform(handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+        UIAlertAction(title: "확인", style: .default, handler: handler)
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- close: #218 
- close: #219 
- close: #220 

## ✨ 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

https://github.com/user-attachments/assets/464eee16-9f9c-4c5e-bf7f-09d797be23f0

- 회고를 끝낼때 Alert를 통해 한 번 더 물어봅니다.
- 오류가 나면 Alert를 통해 알려줍니다.
- 끝난 회고에서 고정을 토글할 수 있습니다.
- iPhone SE (iOS16.0) 정상 작동 확인.

## ⌛ 소요 시간

2h
