### PR TITLE
회고 매니저와 회고 캘린더 매니저 분리

### DIFF
--- a/RetsTalk/.swiftlint.yml
+++ b/RetsTalk/.swiftlint.yml
@@ -12,6 +12,9 @@ trailing_comma:
 nesting:
     type_level:
         warning: 2
+        
+file_length:
+    warning: 500
 
 line_length:
     warning: 120

--- a/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
@@ -164,7 +164,7 @@ extension Retrospect {
         case inProgress
         case finished
         case previous(_ lastRetrospectCreatedDate: Date)
-        case monthly(from: Date, to: Date)
+        case monthly(fromDate: Date, toDate: Date)
         
         func predicate(for userID: UUID) -> CustomPredicate {
             switch self {

--- a/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/RetrospectManager.swift
@@ -214,10 +214,10 @@ final class RetrospectManager: RetrospectManageable {
             return PersistFetchRequest<Retrospect>(fetchLimit: 0)
         }
         
-        let predicate = Retrospect.Kind.predicate(.monthly(from: currentMonth, to: nextMonth))(for: userID)
+        let predicate = Retrospect.Kind.predicate(.monthly(fromDate: currentMonth, toDate: nextMonth))(for: userID)
         return PersistFetchRequest(
             predicate: predicate,
-            fetchLimit: Retrospect.Kind.monthly(from: currentMonth, to: nextMonth).fetchLimit
+            fetchLimit: Retrospect.Kind.monthly(fromDate: currentMonth, toDate: nextMonth).fetchLimit
         )
     }
     

--- a/RetsTalk/RetsTalk/RetrospectCalendar/Controller/RetrospectCalendarTableViewController.swift
+++ b/RetsTalk/RetsTalk/RetrospectCalendar/Controller/RetrospectCalendarTableViewController.swift
@@ -12,7 +12,7 @@ final class RetrospectCalendarTableViewController: BaseViewController {
     private typealias DataSource = UITableViewDiffableDataSource<Section, Retrospect>
     private typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Retrospect>
     
-    private var retrospectManager: RetrospectManageable
+    private var retrospectCalendarManager: RetrospectCalendarManageable
     
     private var dataSource: DataSource?
     private var snapshot: Snapshot?
@@ -25,9 +25,9 @@ final class RetrospectCalendarTableViewController: BaseViewController {
     
     // MARK: Initalization
     
-    init(retrospects: [Retrospect], retrospectManager: RetrospectManageable) {
+    init(retrospects: [Retrospect], retrospectCalendarManager: RetrospectCalendarManageable) {
         self.retrospects = retrospects
-        self.retrospectManager = retrospectManager
+        self.retrospectCalendarManager = retrospectCalendarManager
         
         super.init(nibName: nil, bundle: nil)
     }
@@ -104,7 +104,7 @@ extension RetrospectCalendarTableViewController: UITableViewDelegate {
         guard let retrospect = dataSource?.itemIdentifier(for: indexPath) else { return }
         
         Task {
-            guard let retrospectChatManager = await retrospectManager.retrospectChatManager(of: retrospect)
+            guard let retrospectChatManager = await retrospectCalendarManager.retrospectChatManager(of: retrospect)
             else { return }
             
             let chattingViewController = RetrospectChatViewController(

--- a/RetsTalk/RetsTalk/RetrospectCalendar/Controller/RetrospectCalendarViewController.swift
+++ b/RetsTalk/RetsTalk/RetrospectCalendar/Controller/RetrospectCalendarViewController.swift
@@ -92,7 +92,7 @@ final class RetrospectCalendarViewController: BaseViewController {
         else { return }
         
         Task {
-            await retrospectCalendarManager.fetchRetrospects(of: [.monthly(from: currentMonth, to: nextMonth)])
+            await retrospectCalendarManager.fetchRetrospects(of: [.monthly(fromDate: currentMonth, toDate: nextMonth)])
             let fetchRetrospects = await retrospectCalendarManager.retrospects
             let newRetrospects = filterNewRetrospects(fetchRetrospects)
             retrospectsSubject.send(newRetrospects)

--- a/RetsTalk/RetsTalk/RetrospectCalendar/Controller/RetrospectCalendarViewController.swift
+++ b/RetsTalk/RetsTalk/RetrospectCalendar/Controller/RetrospectCalendarViewController.swift
@@ -213,6 +213,7 @@ extension RetrospectCalendarViewController: UIAdaptivePresentationControllerDele
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         if presentationController.presentedViewController === retrospectTableViewController {
             retrospectTableViewController = nil
+            retrospectCalendarView.deselectDate()
         }
     }
 }

--- a/RetsTalk/RetsTalk/RetrospectCalendar/Controller/RetrospectCalendarViewController.swift
+++ b/RetsTalk/RetsTalk/RetrospectCalendar/Controller/RetrospectCalendarViewController.swift
@@ -9,7 +9,7 @@ import Combine
 import UIKit
 
 final class RetrospectCalendarViewController: BaseViewController {
-    private let retrospectManager: RetrospectManageable
+    private let retrospectCalendarManager: RetrospectCalendarManageable
     
     private let retrospectsSubject: CurrentValueSubject<[Retrospect], Never>
     private let errorSubject: CurrentValueSubject<Error?, Never>
@@ -25,8 +25,8 @@ final class RetrospectCalendarViewController: BaseViewController {
     
     // MARK: Initalization
     
-    init(retrospectManager: RetrospectManageable) {
-        self.retrospectManager = retrospectManager
+    init(retrospectCalendarManager: RetrospectCalendarManageable) {
+        self.retrospectCalendarManager = retrospectCalendarManager
         
         retrospectsSubject = CurrentValueSubject([])
         errorSubject = CurrentValueSubject(nil)
@@ -92,8 +92,8 @@ final class RetrospectCalendarViewController: BaseViewController {
         else { return }
         
         Task {
-            await retrospectManager.fetchRetrospects(of: [.monthly(from: currentMonth, to: nextMonth)])
-            let fetchRetrospects = await retrospectManager.retrospects
+            await retrospectCalendarManager.fetchRetrospects(of: [.monthly(from: currentMonth, to: nextMonth)])
+            let fetchRetrospects = await retrospectCalendarManager.retrospects
             let newRetrospects = filterNewRetrospects(fetchRetrospects)
             retrospectsSubject.send(newRetrospects)
             loadedMonths.append((year, month))
@@ -195,7 +195,7 @@ extension RetrospectCalendarViewController: @preconcurrency UICalendarSelectionS
     -> RetrospectCalendarTableViewController {
         let controller = RetrospectCalendarTableViewController(
             retrospects: retrospects,
-            retrospectManager: retrospectManager
+            retrospectCalendarManager: retrospectCalendarManager
         )
         if let sheet = controller.sheetPresentationController {
             sheet.detents = [.medium(), .large()]

--- a/RetsTalk/RetsTalk/RetrospectCalendar/Model/RetrospectCalendarManageable.swift
+++ b/RetsTalk/RetsTalk/RetrospectCalendar/Model/RetrospectCalendarManageable.swift
@@ -5,3 +5,15 @@
 //  Created by KimMinSeok on 12/5/24.
 //
 
+import Combine
+
+@RetrospectActor
+protocol RetrospectCalendarManageable: Sendable {
+    var retrospects: [Retrospect] { get }
+    var retrospectsPublisher: AnyPublisher<[Retrospect], Never> { get }
+    var errorPublisher: AnyPublisher<Error, Never> { get }
+    
+    func retrospectChatManager(of retrospect: Retrospect) -> RetrospectChatManageable?
+    func fetchRetrospects(of kindList: [Retrospect.Kind])
+    func finishRetrospect(_ retrospect: Retrospect) async
+}

--- a/RetsTalk/RetsTalk/RetrospectCalendar/Model/RetrospectCalendarManageable.swift
+++ b/RetsTalk/RetsTalk/RetrospectCalendar/Model/RetrospectCalendarManageable.swift
@@ -1,0 +1,7 @@
+//
+//  RetrospectCalendarManageable.swift
+//  RetsTalk
+//
+//  Created by KimMinSeok on 12/5/24.
+//
+

--- a/RetsTalk/RetsTalk/RetrospectCalendar/Model/RetrospectCalendarManager.swift
+++ b/RetsTalk/RetsTalk/RetrospectCalendar/Model/RetrospectCalendarManager.swift
@@ -36,7 +36,7 @@ final class RetrospectCalendarManager: RetrospectCalendarManageable {
         retrospects = []
     }
     
-    // MARK: RetrospectCalenarManageable conformance
+    // MARK: RetrospectCalendarManageable conformance
     
     var retrospectsPublisher: AnyPublisher<[Retrospect], Never> {
         retrospectsSubject.eraseToAnyPublisher()

--- a/RetsTalk/RetsTalk/RetrospectCalendar/Model/RetrospectCalendarManager.swift
+++ b/RetsTalk/RetsTalk/RetrospectCalendar/Model/RetrospectCalendarManager.swift
@@ -5,3 +5,171 @@
 //  Created by KimMinSeok on 12/5/24.
 //
 
+import Combine
+import Foundation
+
+final class RetrospectCalendarManager: RetrospectCalendarManageable {
+    private let userID: UUID
+    private var retrospectStorage: Persistable
+    private let retrospectAssistantProvider: RetrospectAssistantProvidable
+    
+    private var retrospectsSubject: CurrentValueSubject<[Retrospect], Never>
+    private(set) var errorSubject: PassthroughSubject<Swift.Error, Never>
+    
+    private(set) var retrospects: [Retrospect] {
+        didSet {
+            retrospectsSubject.send(retrospects)
+        }
+    }
+    
+    // MARK: Initialization
+    
+    init(
+        userID: UUID,
+        retrospectStorage: Persistable,
+        retrospectAssistantProvider: RetrospectAssistantProvidable
+    ) {
+        self.userID = userID
+        self.retrospectStorage = retrospectStorage
+        self.retrospectAssistantProvider = retrospectAssistantProvider
+        
+        retrospectsSubject = CurrentValueSubject([])
+        errorSubject = PassthroughSubject()
+        retrospects = []
+    }
+    
+    // MARK: RetrospectCalenarManageable conformance
+    
+    var retrospectsPublisher: AnyPublisher<[Retrospect], Never> {
+        retrospectsSubject.eraseToAnyPublisher()
+    }
+    var errorPublisher: AnyPublisher<Swift.Error, Never> {
+        errorSubject.eraseToAnyPublisher()
+    }
+    
+    func retrospectChatManager(of retrospect: Retrospect) -> (any RetrospectChatManageable)? {
+        guard let retrospect = retrospects.first(where: { $0.id == retrospect.id })
+        else {
+            errorSubject.send(Error.invalidRetrospect)
+            return nil
+        }
+        
+        let retrospectChatManager = RetrospectChatManager(
+            retrospect: retrospect,
+            messageStorage: retrospectStorage,
+            assistantMessageProvider: retrospectAssistantProvider,
+            retrospectChatManagerListener: self
+        )
+        return retrospectChatManager
+    }
+    
+    func fetchRetrospects(of kindList: [Retrospect.Kind]) {
+        do {
+            for kind in kindList {
+                let request = retrospectFetchRequest(for: kind)
+                let fetchedRetrospects = try retrospectStorage.fetch(by: request)
+                for retrospect in fetchedRetrospects where !retrospects.contains(retrospect) {
+                    retrospects.append(retrospect)
+                }
+            }
+        } catch {
+            errorSubject.send(error)
+        }
+    }
+    
+    func finishRetrospect(_ retrospect: Retrospect) async {
+        do {
+            var updatingRetrospect = retrospect
+            if updatingRetrospect.status == .finished {
+                updatingRetrospect.summary = try await retrospectAssistantProvider.requestSummary(for: retrospect.chat)
+            }
+            let updatedRetrospect = try retrospectStorage.update(from: retrospect, to: updatingRetrospect)
+            updateRetrospects(by: updatedRetrospect)
+        } catch {
+            errorSubject.send(error)
+        }
+    }
+    
+    // MARK: Support retrospects fetching
+    
+    private func retrospectFetchRequest(for kind: Retrospect.Kind) -> PersistFetchRequest<Retrospect> {
+        PersistFetchRequest<Retrospect>(
+            predicate: kind.predicate(for: userID),
+            sortDescriptors: [CustomSortDescriptor(key: "createdAt", ascending: false)],
+            fetchLimit: kind.fetchLimit
+        )
+    }
+    
+    // MARK: Manage retrospects
+    
+    private var isPinAvailable: Bool {
+        retrospects.filter({ $0.isPinned }).count < Numerics.pinLimit
+    }
+    
+    private func updateRetrospects(by retrospect: Retrospect) {
+        guard let matchingIndex = retrospects.firstIndex(where: { $0.id == retrospect.id }) else { return }
+        
+        retrospects[matchingIndex] = retrospect
+    }
+}
+
+// MARK: - RetrospectChatManagerListener conformance
+
+extension RetrospectCalendarManager: RetrospectChatManagerListener {
+    func didUpdateRetrospect(_ retrospectChatManageable: RetrospectChatManageable, retrospect: Retrospect) throws {
+        guard let matchingIndex = retrospects.firstIndex(where: { $0.id == retrospect.id })
+        else { return }
+        
+        if !retrospects[matchingIndex].isEqualInStorage(retrospect) {
+            Task {
+                let updatedRetrospect = try retrospectStorage.update(from: retrospects[matchingIndex], to: retrospect)
+                switch updatedRetrospect.status {
+                case .finished:
+                    await finishRetrospect(updatedRetrospect)
+                default:
+                    break
+                }
+            }
+        }
+        retrospects[matchingIndex] = retrospect
+    }
+    
+    func shouldTogglePin(_ retrospectChatManageable: RetrospectChatManageable, retrospect: Retrospect) -> Bool {
+        retrospect.isPinned || isPinAvailable
+    }
+}
+
+// MARK: - Error
+
+fileprivate extension RetrospectCalendarManager {
+    enum Error: LocalizedError {
+        case faildedFetch
+        case invalidRetrospect
+        
+        var errorDescription: String? {
+            switch self {
+            case .faildedFetch:
+                "회고를 불러올 수 없습니다."
+            case .invalidRetrospect:
+                "존재하지 않는 회고입니다."
+            }
+        }
+        
+        var failureReason: String? {
+            switch self {
+            case .faildedFetch:
+                "회고를 불러올 수 없습니다."
+            case .invalidRetrospect:
+                "존재하지 않는 회고입니다."
+            }
+        }
+    }
+}
+
+// MARK: - Constant
+
+private extension RetrospectCalendarManager {
+    enum Numerics {
+        static let pinLimit = 2
+    }
+}

--- a/RetsTalk/RetsTalk/RetrospectCalendar/Model/RetrospectCalendarManager.swift
+++ b/RetsTalk/RetsTalk/RetrospectCalendar/Model/RetrospectCalendarManager.swift
@@ -13,18 +13,19 @@ final class RetrospectCalendarManager: RetrospectCalendarManageable {
     private var retrospectStorage: Persistable
     private let retrospectAssistantProvider: RetrospectAssistantProvidable
     
-    private var retrospectsSubject: CurrentValueSubject<[Retrospect], Never>
-    private(set) var errorSubject: PassthroughSubject<Swift.Error, Never>
+    private var retrospectsSubject: CurrentValueSubject<[Retrospect], Never> = .init([])
+    private(set) var errorSubject: PassthroughSubject<Swift.Error, Never> = .init()
     
     private(set) var retrospects: [Retrospect] {
         didSet {
+            print(retrospects)
             retrospectsSubject.send(retrospects)
         }
     }
     
     // MARK: Initialization
     
-    init(
+    nonisolated init(
         userID: UUID,
         retrospectStorage: Persistable,
         retrospectAssistantProvider: RetrospectAssistantProvidable
@@ -33,8 +34,6 @@ final class RetrospectCalendarManager: RetrospectCalendarManageable {
         self.retrospectStorage = retrospectStorage
         self.retrospectAssistantProvider = retrospectAssistantProvider
         
-        retrospectsSubject = CurrentValueSubject([])
-        errorSubject = PassthroughSubject()
         retrospects = []
     }
     

--- a/RetsTalk/RetsTalk/RetrospectCalendar/Model/RetrospectCalendarManager.swift
+++ b/RetsTalk/RetsTalk/RetrospectCalendar/Model/RetrospectCalendarManager.swift
@@ -18,7 +18,6 @@ final class RetrospectCalendarManager: RetrospectCalendarManageable {
     
     private(set) var retrospects: [Retrospect] {
         didSet {
-            print(retrospects)
             retrospectsSubject.send(retrospects)
         }
     }

--- a/RetsTalk/RetsTalk/RetrospectCalendar/Model/RetrospectCalendarManager.swift
+++ b/RetsTalk/RetsTalk/RetrospectCalendar/Model/RetrospectCalendarManager.swift
@@ -1,0 +1,7 @@
+//
+//  RetrospectCalendarManager.swift
+//  RetsTalk
+//
+//  Created by KimMinSeok on 12/5/24.
+//
+

--- a/RetsTalk/RetsTalk/RetrospectCalendar/View/RetrospectCalendarView.swift
+++ b/RetsTalk/RetsTalk/RetrospectCalendar/View/RetrospectCalendarView.swift
@@ -56,6 +56,12 @@ final class RetrospectCalendarView: BaseView {
     func currentDataComponents() -> DateComponents {
         retrospectCalendarView.visibleDateComponents
     }
+    
+    func deselectDate() {
+        if let dateSelection = retrospectCalendarView.selectionBehavior as? UICalendarSelectionSingleDate {
+            dateSelection.selectedDate = nil
+        }
+    }
 }
 
 // MARK: - Subviews layouts


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #216 

## ✨ 세부 내용
### 회고 매니저와 회고 캘린더 매니저 분리
중복되는 부분이 많아서 추후에 상속으로 변경해야할 것 같습니다.

### 짜잘한 변경
- monthly 파라미터 네이밍에 대한 변경
`case monthly(fromDate: Date, toDate: Date)`
- Swift Lint File Length를 500부터 warning 표시하도록 변경

<!-- 수정/추가한 내용을 적어주세요. -->

## ✍️ 고민한 내용
### 중첩되는 부분
사실 manager를 회고 매니저로 같이 쓰면
1. 회고 캘린더에서 한달을 가져오면
2. 회고 리스트에 돌아갔을때 중첩 에러가 날거라 생각

그래서 리스트와 캘린더 매니저를 분리

하지만 문제점은 두 부분이 완전 똑같음

- 회고 캘린더 매니저
```swift
@RetrospectActor
protocol RetrospectCalendarManageable: Sendable {
    var retrospects: [Retrospect] { get }
    var retrospectsPublisher: AnyPublisher<[Retrospect], Never> { get }
    var errorPublisher: AnyPublisher<Error, Never> { get }
    
    func retrospectChatManager(of retrospect: Retrospect) -> RetrospectChatManageable?
    func fetchRetrospects(of kindList: [Retrospect.Kind])
    func finishRetrospect(_ retrospect: Retrospect) async
}
```

- 회고 매니저
```swift
@RetrospectActor
protocol RetrospectManageable: Sendable {
    var retrospects: [Retrospect] { get }
    var retrospectsPublisher: AnyPublisher<SortedRetrospects, Never> { get }
    var errorPublisher: AnyPublisher<Swift.Error?, Never> { get }

    func createRetrospect() -> RetrospectChatManageable?
    func retrospectChatManager(of retrospect: Retrospect) -> RetrospectChatManageable?
    func fetchRetrospects(of kindList: [Retrospect.Kind])
    func fetchPreviousRetrospects() -> Int
    func fetchRetrospectsCount() -> (totalCount: Int, monthlyCount: Int)?
    func togglePinRetrospect(_ retrospect: Retrospect)
    func finishRetrospect(_ retrospect: Retrospect) async
    func deleteRetrospect(_ retrospect: Retrospect)
    func refreshRetrospectStorage(iCloudEnabled: Bool)
}
```

<!-- 해당 PR중 고민한 내용이 있으면 적어주세요. -->

## ⌛ 소요 시간
1h