### PR TITLE
UserID 고정, CloudKit 연결 시 셀에 중복된 회고가 보이는 문제 해결, 회고 프롬프트 수정

### DIFF
--- a/RetsTalk/RetsTalk/App/SceneDelegate.swift
+++ b/RetsTalk/RetsTalk/App/SceneDelegate.swift
@@ -20,9 +20,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         let userDefaultsManager = UserDefaultsManager()
         let userSettingManager = UserSettingManager(userDataStorage: userDefaultsManager)
-    
-        let (userID, isFirstLaunch) = userSettingManager.initialize()
         
+        let (userID, isFirstLaunch) = userSettingManager.initialize()
         let coreDataManager = CoreDataManager(
             inMemory: false,
             isiCloudSynced: userSettingManager.userData.isCloudSyncOn,

--- a/RetsTalk/RetsTalk/Network/CLOVAStudio/CLOVAStudioManager+SummaryProvider.swift
+++ b/RetsTalk/RetsTalk/Network/CLOVAStudio/CLOVAStudioManager+SummaryProvider.swift
@@ -39,7 +39,7 @@ extension CLOVAStudioManager: SummaryProvider {
             var messageContents = chat.map({ $0.content })
             messageContents.removeLast()
             let messageContentsString = messageContents.joined(separator: "\n")
-            messageParameters.append(MessageDTO(role: "assistant", content: messageContentsString))
+            messageParameters.append(MessageDTO(role: "user", content: messageContentsString))
             messages = messageParameters
         }
     }

--- a/RetsTalk/RetsTalk/Network/CLOVAStudio/CLOVAStudioManager+SummaryProvider.swift
+++ b/RetsTalk/RetsTalk/Network/CLOVAStudio/CLOVAStudioManager+SummaryProvider.swift
@@ -36,7 +36,10 @@ extension CLOVAStudioManager: SummaryProvider {
         init(chat: [Message]) {
             var messageParameters = [MessageDTO]()
             messageParameters.append(MessageDTO.summaryRequestMessage)
-            messageParameters.append(contentsOf: chat.map({MessageDTO(role: $0.role.rawValue, content: $0.content)}))
+            var messageContents = chat.map({ $0.content })
+            messageContents.removeLast()
+            let messageContentsString = messageContents.joined(separator: "\n")
+            messageParameters.append(MessageDTO(role: "assistant", content: messageContentsString))
             messages = messageParameters
         }
     }
@@ -63,7 +66,7 @@ extension CLOVAStudioManager: SummaryProvider {
             role: "system",
             // swiftlint:disable line_length
             content: """
-            당신은 주어진 텍스트를 1줄로 간결하고 명확하게 요약하는 텍스트 요약 어시스턴트입니다.\n\t•\t텍스트에서 핵심 정보를 추출하여 하나의 문장으로 요약하세요.\n\t•\t사용자의 대화 의도와 감정을 반영하며, 자연스럽고 간결하게 작성하세요.\n\t•\t결과는 불필요한 부가 요소 없이 하나의 완전한 문장으로 작성해야 합니다.\n\t•\t대화가 짧거나 회고할 만한 것이 없는 경우에는 “보통의 하루를 보냄”이라고 요약하세요.\n\n\n예시 입력과 출력\n\t•\t입력\n“오늘 하루 동안 있었던 일들을 한번 되돌아볼까요? 어떤 일들이 있었는지 생각해 보세요.\n오늘은 팀 프로젝트 리팩토링 작업을 했어\n팀 프로젝트 리팩토링 작업을 하셨군요. 오늘 그 작업을 하면서 어떤 감정을 느끼셨나요?\n아쉬웠어\n리팩토링 작업이 아쉬우셨군요. 어떤 부분이 아쉬우셨나요?\n많은 걸 못한것 같아서 아쉬웠어\n그런 마음이 드실 수 있죠. 그래도 오늘 한 작업도 분명히 의미가 있을 거예요. 혹시 이 작업을 통해 배운 점이 있으신가요?\nNotificationCenter와 delegate의 차이점을 학습할 수 있었어”\n출력\n“팀 프로젝트 리팩토링 작업을 하며 NotificationCenter와 delegate의 차이점을 학습함”\n\t•\t입력\n“오늘은 별다른 일이 없었어. 그냥 평범한 하루였던 것 같아.”\n출력\n보통의 하루를 보냄\n\n\n목표\n\t•\t간결하고 명확한 한 줄 요약을 생성하는 것이 목표입니다.\n\t•\t회고할 만한 정보가 부족한 경우에도 간결한 요약을 제공할 수 있도록 보완하세요.
+            당신은 주어진 텍스트를 단 한 줄로 간결하고 명확하게 요약하는 텍스트 요약 어시스턴트입니다.\n\t•\t핵심 정보를 추출하여 불필요한 부가 요소 없이 하나의 문장으로 요약합니다.\n\t•\t사용자의 대화 의도와 감정을 반영하며 자연스럽게 작성합니다.\n\t•\t대화가 짧거나 없으면 “보통의 하루를 보냄”으로 요약합니다.\n\t•\t결과에는 불필요한 접두어나 불필요한 부가 요소를 포함하지 않습니다.\n\t•\t단순히 텍스트를 요약하며, 추가적인 대화를 이어나가지 않습니다.\n아무런 입력이 없으면 \"보통의 하루를 보냄\"이라는 메시지를 줘\n\n목표\n\t•\t간결하고 명확한 한 줄 요약 생성.\n\t•\t대화를 확장하지 않고 요약만 수행.
             """
             // swiftlint:enable line_length
         )

--- a/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectListViewController.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Controller/RetrospectListViewController.swift
@@ -14,7 +14,6 @@ final class RetrospectListViewController: BaseViewController {
     private typealias Snapshot = NSDiffableDataSourceSnapshot<RetrospectSection, Retrospect>
     private typealias RetrospectDataSource = UITableViewDiffableDataSource<RetrospectSection, Retrospect>
     
-    
     private let retrospectManager: RetrospectManageable
     private let userDefaultsManager: Persistable
     private let userSettingManager: UserSettingManager

--- a/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
+++ b/RetsTalk/RetsTalk/Retrospect/Model/Retrospect.swift
@@ -72,7 +72,6 @@ extension Retrospect: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
         hasher.combine(userID)
-        hasher.combine(chat.count)
         hasher.combine(status)
         hasher.combine(summary)
         hasher.combine(isPinned)
@@ -81,7 +80,6 @@ extension Retrospect: Hashable {
     static func == (lhs: Retrospect, rhs: Retrospect) -> Bool {
         lhs.id == rhs.id
         && lhs.userID == rhs.userID
-        && lhs.chat.count == rhs.chat.count
         && lhs.status == rhs.status
         && lhs.summary == rhs.summary
         && lhs.isPinned == rhs.isPinned

--- a/RetsTalk/RetsTalk/User/Model/UserSettingManageable.swift
+++ b/RetsTalk/RetsTalk/User/Model/UserSettingManageable.swift
@@ -17,7 +17,7 @@ protocol UserSettingManageable: Sendable, ObservableObject {
     /// 비동기적으로 저장된 사용자 정보를 가져오고 아이디를 반환합니다.
     /// 만약 정보가 없으면, 새로운 사용자 정보를 저장하고 반환합니다.
     /// - Returns: 사용자 아이디
-    func initialize() -> (userID: UUID?, isFirstLaunch: Bool) 
+    func initialize() -> (userID: UUID?, isFirstLaunch: Bool)
     /// 로컬 저장소의 사용자 데이터를 가져옵니다.
     func fetch()
     /// 로컬 저장소의 사용자 정보를 업데이트합니다.

--- a/RetsTalk/RetsTalk/User/Model/UserSettingManager.swift
+++ b/RetsTalk/RetsTalk/User/Model/UserSettingManager.swift
@@ -111,7 +111,7 @@ final class UserSettingManager: UserSettingManageable, ObservableObject {
     }
 
     private func initializeUserData() -> UUID? {
-        let newUserID = UUID()
+        let newUserID = Constants.defaultUUID
         let newNickname = randomNickname()
         let newUserData = UserData(dictionary: ["userID": newUserID.uuidString, "nickname": newNickname])
 


### PR DESCRIPTION
##  📌 관련 이슈

- closed: #235 
- closed: #237 
- closed: #238 
## ✨ 세부 내용
### UserID
앱 실행시 UserID를 고정하였습니다.

### 회고가 중복해서 보이는 문제
CloudKit 연동시 FetchInitialize 함수가 동작합니다. 이때 로컬에서 생성된 회고가 중복하여 보이는 문제가 있었습니다.
원인은 동일한 회고인데 chat 배열이 비어있는 회고가 중복되어 retrospects에 들어가는 문제였습니다.
원인 자체 해결은 아직이나, 임시로 Retrospect의 hash 함수의 조건에서 chat.count를 제외하여 해결하였습니다.
### 요약 프롬프트 개선
기존 요약 프롬프트는 채팅과 동일한 로직이었습니다. 이를 content만 한곳에 모아 새로운 content로 만든 뒤, role: user 인 하나의 Message를 요약해달라고 요청하는 방식으로 수정하였습니다.

## ✍️ 고민한 내용



## ⌛ 소요 시간